### PR TITLE
add data integrity verifiable presentation as proof of possession

### DIFF
--- a/examples/credential_request_ldp_vc_vp.json
+++ b/examples/credential_request_ldp_vc_vp.json
@@ -16,11 +16,11 @@
       }
    },
    "proof": {
-      "proof_type": "ldp_vp_2.0",
+      "proof_type": "ldp_vp",
       "ldp_vp": {
          "@context": [
-             "https://www.w3.org/ns/credentials/v2",
-             "https://www.w3.org/ns/credentials/examples/v2"
+            "https://www.w3.org/ns/credentials/v2",
+            "https://www.w3.org/ns/credentials/examples/v2"
          ],
          "type": [
             "VerifiablePresentation"

--- a/examples/credential_request_ldp_vc_vp.json
+++ b/examples/credential_request_ldp_vc_vp.json
@@ -19,7 +19,8 @@
       "proof_type": "ldp_vp_2.0",
       "ldp_vp": {
          "@context": [
-            "https://www.w3.org/2018/credentials/v1"
+             "https://www.w3.org/ns/credentials/v2",
+             "https://www.w3.org/ns/credentials/examples/v2"
          ],
          "type": [
             "VerifiablePresentation"

--- a/examples/credential_request_ldp_vc_vp.json
+++ b/examples/credential_request_ldp_vc_vp.json
@@ -1,0 +1,42 @@
+{
+   "format": "ldp_vc",
+   "credential_definition": {
+      "@context": [
+         "https://www.w3.org/2018/credentials/v1",
+         "https://www.w3.org/2018/credentials/examples/v1"
+      ],
+      "type": [
+         "VerifiableCredential",
+         "UniversityDegreeCredential"
+      ],
+      "credentialSubject": {
+         "degree": {
+            "type": {}
+         }
+      }
+   },
+   "proof": {
+      "proof_type": "ldp_vp_2.0",
+      "ldp_vp": {
+         "@context": [
+            "https://www.w3.org/2018/credentials/v1"
+         ],
+         "type": [
+            "VerifiablePresentation"
+         ],
+         "holder": "did:key:z6MkvrFpBNCoYewiaeBLgjUDvLxUtnK5R6mqh5XPvLsrPsro",
+         "proof": [
+            {
+               "type": "DataIntegrityProof",
+               "cryptosuite": "eddsa-2022",
+               "proofPurpose": "authentication",
+               "verificationMethod": "did:key:z6MkvrFpBNCoYewiaeBLgjUDvLxUtnK5R6mqh5XPvLsrPsro#z6MkvrFpBNCoYewiaeBLgjUDvLxUtnK5R6mqh5XPvLsrPsro",
+               "created": "2023-03-01T14:56:29.280619Z",
+               "challenge": "82d4cb36-11f6-4273-b9c6-df1ac0ff17e9",
+               "domain": "did:web:audience.company.com",
+               "proofValue": "z5hrbHzZiqXHNpLq6i7zePEUcUzEbZKmWfNQzXcUXUrqF7bykQ7ACiWFyZdT2HcptF1zd1t7NhfQSdqrbPEjZceg7"
+            }
+         ]
+      }
+   }
+}

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -735,7 +735,7 @@ This specification defines the following values for the `proof_type` property:
 
 * `jwt`: A JWT [@!RFC7519] is used as proof of possession. When `proof_type` is `jwt`, a `proof` object MUST include a `jwt` claim containing a JWT defined in (#jwt-proof-type).
 * `cwt`: A CWT [@!RFC8392] is used as proof of possession. When `proof_type` is `cwt`, a `proof` object MUST include a `cwt` claim containing a CWT defined in (#cwt-proof-type).
-* `ldp_vp_2.0`: A verifiable presentation signed using data integrity proof as defined in [@VC_DATA_2.0] and [@DI] specs must be used as a proof of possession. When `proof_type` is `ldp_vp_2.0`, a `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
+* `ldp_vp_2.0`: A verifiable presentation signed using the data integrity proof defined in [@VC_DATA_2.0], and where the proof of possession MUST be done in accordance with [@DI]. When `proof_type` is set to `ldp_vp_2.0`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
 
 #### `jwt` Key Proof Type {#jwt-proof-type}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -819,7 +819,8 @@ Below is a non-normative example of a `proof` parameter:
   "proof_type": "ldp_vp_2.0",
   "ldp_vp": {
          "@context": [
-            "https://www.w3.org/2018/credentials/v1"
+             "https://www.w3.org/ns/credentials/v2",
+             "https://www.w3.org/ns/credentials/examples/v2"
          ],
          "type": [
             "VerifiablePresentation"

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1504,17 +1504,6 @@ TBD
   </front>
 </reference>
 
-<reference anchor="RFC6750" target="https://www.rfc-editor.org/rfc/rfc6750">
-  <front>
-    <title>The OAuth 2.0 Authorization Framework: Bearer Token Usage</title>
-    <author fullname="Dick Hardt">
-      <organization>Independent</organization>
-    </author>
-    <author fullname="Michael B. Jones">
-      <organization>Microsoft</organization>
-    </author>
-   <date month="October" year="2012"/>
-  </front>
 <reference anchor="USASCII">
         <front>
           <title>Coded Character Set -- 7-bit American Standard Code for Information Interchange</title>

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -835,7 +835,7 @@ Here is another example JWT not only proving possession of a private key but als
 
 #### `ldp_vp` Key Proof Type {#ldp_vp-proof-type}
 
-The verifiable presentation as defined by [@VC_DATA_2.0] or [@VC_DATA] signed using Data Integrity that are used as Key Proofs MUST contain the following elements:
+When a W3C Verifiable Presentation as defined by [@VC_DATA_2.0] or [@VC_DATA] signed using Data Integrity is used as Key Proof, it MUST contain the following elements:
 
   * in the presentation itself,
       * `holder`: OPTIONAL. MUST be equivalent to the controller identifier (e.g. DID) for the verificationMethod identified by the `proof.verificationMethod` property.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -808,7 +808,7 @@ The verifiable presentation as defined by [@VC_DATA_2.0] signed using Data Integ
 
   * in the proof body, 
       * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.
-      * `challenge`: REQUIRED (string). The value type of this claim MUST be a string, where the value is a server-provided `c_nonce`. MUST be present when the Wallet received server-provided `c_nonce`.
+      * `challenge`: REQUIRED (string). The value type of this claim MUST be a string, where the value is a server-provided `c_nonce`. It MUST be present when the Wallet received server-provided `c_nonce`.
 
 The Credential Issuer MUST validate that the `proof` is actually signed by a key of the holder.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -804,7 +804,7 @@ Here is another example JWT not only proving possession of a private key but als
 The verifiable presentation as defined by [@VC_DATA_2.0] or [@VC_DATA] signed using Data Integrity that are used as Key Proofs MUST contain the following elements:
 
   * in the presentation itself,
-      * `holder`: OPTIONAL. MUST be equivalent to the verificationMethod identifier (e.g. DID) in the `proof.verificationMethod` property.
+      * `holder`: OPTIONAL. MUST be equivalent to the controller identifier (e.g. DID) for the verificationMethod identified by the `proof.verificationMethod` property.
 
   * in the proof body, 
       * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -735,7 +735,7 @@ This specification defines the following values for the `proof_type` property:
 
 * `jwt`: A JWT [@!RFC7519] is used as proof of possession. When `proof_type` is `jwt`, a `proof` object MUST include a `jwt` claim containing a JWT defined in (#jwt-proof-type).
 * `cwt`: A CWT [@!RFC8392] is used as proof of possession. When `proof_type` is `cwt`, a `proof` object MUST include a `cwt` claim containing a CWT defined in (#cwt-proof-type).
-* `ldp_vp_2.0`: A verifiable presentation signed using the Data Integrity Proof defined in [@VC_DATA_2.0], and where the proof of possession MUST be done in accordance with [@DI]. When `proof_type` is set to `ldp_vp_2.0`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
+* `ldp_vp`: A verifiable presentation signed using the Data Integrity Proof defined in [@VC_DATA_2.0] or [@VC_DATA], and where the proof of possession MUST be done in accordance with [@DI]. When `proof_type` is set to `ldp_vp`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
 
 #### `jwt` Key Proof Type {#jwt-proof-type}
 
@@ -799,9 +799,9 @@ Here is another example JWT not only proving possession of a private key but als
 }
 ```
 
-#### `ldp_vp_2.0` Key Proof Type {#ldp_vp-proof-type}
+#### `ldp_vp` Key Proof Type {#ldp_vp-proof-type}
 
-The verifiable presentation as defined by [@VC_DATA_2.0] signed using Data Integrity that are used as Key Proofs MUST contain the following elements:
+The verifiable presentation as defined by [@VC_DATA_2.0] or [@VC_DATA] signed using Data Integrity that are used as Key Proofs MUST contain the following elements:
 
   * in the presentation itself,
       * `holder`: OPTIONAL. MUST be equivalent to the verificationMethod identifier (e.g. DID) in the `proof.verificationMethod` property.
@@ -816,7 +816,7 @@ Below is a non-normative example of a `proof` parameter:
 
 ```json
 {
-  "proof_type": "ldp_vp_2.0",
+  "proof_type": "ldp_vp",
   "ldp_vp": {
          "@context": [
              "https://www.w3.org/ns/credentials/v2",

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1956,7 +1956,7 @@ The following is a non-normative example of a Credential Request with Credential
 
 <{{examples/credential_request_ldp_vc.json}}
 
-For better suiting the W3C Data Integrity Proof ecosystem the following non-normative example displays a Credential request with the proof of possession type set to `ldp_vp`, using a verifiable presentation.
+The following is a non-normative example of a Credential request with the key proof type `ldp_vp`:
 
 <{{examples/credential_request_ldp_vc_vp.json}}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -838,7 +838,7 @@ Here is another example JWT not only proving possession of a private key but als
 When a W3C Verifiable Presentation as defined by [@VC_DATA_2.0] or [@VC_DATA] signed using Data Integrity is used as Key Proof, it MUST contain the following elements:
 
   * in the presentation itself,
-      * `holder`: OPTIONAL. MUST be equivalent to the controller identifier (e.g. DID) for the verificationMethod identified by the `proof.verificationMethod` property.
+      * `holder`: OPTIONAL. MUST be equivalent to the controller identifier (e.g. DID) for the `verificationMethod` value identified by the `proof.verificationMethod` property.
 
   * in the proof body, 
       * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -841,7 +841,7 @@ When a W3C Verifiable Presentation as defined by [@VC_DATA_2.0] or [@VC_DATA] si
 
   * `proof`: REQUIRED. The proof body of a W3C Verifiable Presentation. 
       * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.
-      * `challenge`: REQUIRED (string). The value type of this claim MUST be a string, where the value is a server-provided `c_nonce`. It MUST be present when the Wallet received server-provided `c_nonce`.
+      * `challenge`: REQUIRED when the Credential Issuer has provided a `c_nonce`. MUST NOT be used otherwise. String, where the value is a server-provided `c_nonce`. It MUST be present when the Wallet received server-provided `c_nonce`.
 
 The Credential Issuer MUST validate that the `proof` is actually signed with a key in possession of the Holder.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -769,7 +769,7 @@ This specification defines the following values for the `proof_type` property:
 
 * `jwt`: A JWT [@!RFC7519] is used as proof of possession. When `proof_type` is `jwt`, a `proof` object MUST include a `jwt` claim containing a JWT defined in (#jwt-proof-type).
 * `cwt`: A CWT [@!RFC8392] is used as proof of possession. When `proof_type` is `cwt`, a `proof` object MUST include a `cwt` claim containing a CWT defined in (#cwt-proof-type).
-* `ldp_vp`: A verifiable presentation signed using the Data Integrity Proof defined in [@VC_DATA_2.0] or [@VC_DATA], and where the proof of possession MUST be done in accordance with [@DI]. When `proof_type` is set to `ldp_vp`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
+* `ldp_vp`: A verifiable presentation signed using the Data Integrity Proof defined in [@VC_DATA_2.0] or [@VC_DATA], and where the proof of possession MUST be done in accordance with [@Data_Integrity]. When `proof_type` is set to `ldp_vp`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
 
 #### `jwt` Key Proof Type {#jwt-proof-type}
 
@@ -1494,7 +1494,7 @@ TBD
   </front>
 </reference>
 
-<reference anchor="DI" target="https://w3c.github.io/vc-data-integrity/">
+<reference anchor="Data_Integrity" target="https://w3c.github.io/vc-data-integrity/">
   <front>
     <title>Verifiable Credential Data Integrity 1.0</title>
     <author fullname="Manu Sporny">

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -837,10 +837,9 @@ Here is another example JWT not only proving possession of a private key but als
 
 When a W3C Verifiable Presentation as defined by [@VC_DATA_2.0] or [@VC_DATA] signed using Data Integrity is used as Key Proof, it MUST contain the following elements:
 
-  * in the presentation itself,
-      * `holder`: OPTIONAL. MUST be equivalent to the controller identifier (e.g. DID) for the `verificationMethod` value identified by the `proof.verificationMethod` property.
+  * `holder`: OPTIONAL. MUST be equivalent to the controller identifier (e.g. DID) for the `verificationMethod` value identified by the `proof.verificationMethod` property.
 
-  * in the proof body, 
+  * `proof`: REQUIRED. The proof body of a W3C Verifiable Presentation. 
       * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.
       * `challenge`: REQUIRED (string). The value type of this claim MUST be a string, where the value is a server-provided `c_nonce`. It MUST be present when the Wallet received server-provided `c_nonce`.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -801,7 +801,7 @@ Here is another example JWT not only proving possession of a private key but als
 
 #### `ldp_vp_2.0` Key Proof Type {#ldp_vp-proof-type}
 
-The verifiable presentation MUST contain the following elements:
+The verifiable presentation as defined by [@VC_DATA_2.0] signed using Data Integrity that are used as Key Proofs MUST contain the following elements:
 
   * in the presentation itself,
       * `holder`: OPTIONAL. MUST be equivalent to the DID in the `proof.verificationMethod` property.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -735,7 +735,7 @@ This specification defines the following values for the `proof_type` property:
 
 * `jwt`: A JWT [@!RFC7519] is used as proof of possession. When `proof_type` is `jwt`, a `proof` object MUST include a `jwt` claim containing a JWT defined in (#jwt-proof-type).
 * `cwt`: A CWT [@!RFC8392] is used as proof of possession. When `proof_type` is `cwt`, a `proof` object MUST include a `cwt` claim containing a CWT defined in (#cwt-proof-type).
-* `ldp_vp_2.0`: A verifiable presentation signed using the data integrity proof defined in [@VC_DATA_2.0], and where the proof of possession MUST be done in accordance with [@DI]. When `proof_type` is set to `ldp_vp_2.0`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
+* `ldp_vp_2.0`: A verifiable presentation signed using the Data Integrity Proof defined in [@VC_DATA_2.0], and where the proof of possession MUST be done in accordance with [@DI]. When `proof_type` is set to `ldp_vp_2.0`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
 
 #### `jwt` Key Proof Type {#jwt-proof-type}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -735,6 +735,7 @@ This specification defines the following values for the `proof_type` property:
 
 * `jwt`: A JWT [@!RFC7519] is used as proof of possession. When `proof_type` is `jwt`, a `proof` object MUST include a `jwt` claim containing a JWT defined in (#jwt-proof-type).
 * `cwt`: A CWT [@!RFC8392] is used as proof of possession. When `proof_type` is `cwt`, a `proof` object MUST include a `cwt` claim containing a CWT defined in (#cwt-proof-type).
+* `ldp_vp_2.0`: A verifiable presentation signed using data integrity proof as defined in [@VC_DATA_2.0] and [@DI] specs must be used as a proof of possession. When `proof_type` is `ldp_vp_2.0`, a `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
 
 #### `jwt` Key Proof Type {#jwt-proof-type}
 
@@ -796,6 +797,49 @@ Here is another example JWT not only proving possession of a private key but als
   "iat": 1659145924,
   "nonce": "tZignsnFbp"
 }
+```
+
+#### `ldp_vp_2.0` Key Proof Type {#ldp_vp-proof-type}
+
+The verifiable presentation MUST contain the following elements:
+
+  * in the presentation itself,
+      * `holder`: OPTIONAL. MUST be equivalent to the DID in the `proof.verificationMethod` property.
+
+  * in the proof body, 
+      * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.
+      * `challenge`: REQUIRED (string). The value type of this claim MUST be a string, where the value is a server-provided `c_nonce`. MUST be present when the Wallet received server-provided `c_nonce`.
+
+The Credential Issuer MUST validate that the `proof` is actually signed by a key of the holder.
+
+Below is a non-normative example of a `proof` parameter:
+
+```json
+{
+  "proof_type": "ldp_vp_2.0",
+  "ldp_vp": {
+         "@context": [
+            "https://www.w3.org/2018/credentials/v1"
+         ],
+         "type": [
+            "VerifiablePresentation"
+         ],
+         "holder": "did:key:z6MkvrFpBNCoYewiaeBLgjUDvLxUtnK5R6mqh5XPvLsrPsro",
+         "proof": [
+            {
+               "type": "DataIntegrityProof",
+               "cryptosuite": "eddsa-2022",
+               "proofPurpose": "authentication",
+               "verificationMethod": "did:key:z6MkvrFpBNCoYewiaeBLgjUDvLxUtnK5R6mqh5XPvLsrPsro#z6MkvrFpBNCoYewiaeBLgjUDvLxUtnK5R6mqh5XPvLsrPsro",
+               "created": "2023-03-01T14:56:29.280619Z",
+               "challenge": "82d4cb36-11f6-4273-b9c6-df1ac0ff17e9",
+               "domain": "did:web:audience.company.com",
+               "proofValue": "z5hrbHzZiqXHNpLq6i7zePEUcUzEbZKmWfNQzXcUXUrqF7bykQ7ACiWFyZdT2HcptF1zd1t7NhfQSdqrbPEjZceg7"
+            }
+         ]
+      }
+  }
+
 ```
 
 #### `cwt` Key Proof Type {#cwt-proof-type}
@@ -1374,6 +1418,68 @@ TBD
   </front>
 </reference>
 
+<reference anchor="VC_DATA_2.0" target="https://www.w3.org/TR/vc-data-model-2.0">
+  <front>
+    <title>Verifiable Credentials Data Model 2.0</title>
+    <author fullname="Manu Sporny">
+      <organization>Digital Bazaar</organization>
+    </author>
+    <author fullname="Orie Steele">
+      <organization>Transmute</organization>
+    </author>
+    <author fullname="Oliver Terbu">
+      <organization>Spruce Systems, Inc.</organization>
+    </author>
+    <author fullname="Grant Noble">
+      <organization>ConsenSys</organization>
+    </author>
+    <author fullname="Gabe Cohen">
+      <organization>Block</organization>
+    </author>
+    <author fullname="Michael B. Jones">
+      <organization>independent</organization>
+    </author>
+    <author fullname="Dave Longley">
+      <organization>Digital Bazaar</organization>
+    </author>
+    <author fullname="Daniel C. Burnett">
+      <organization>ConsenSys</organization>
+    </author>
+    <author fullname="Brent Zundel">
+      <organization>Evernym</organization>
+    </author>
+    <author fullname="Kyle Den Hartog">
+      <organization>MATTR</organization>
+    </author>
+    <author fullname="David Chadwick">
+      <organization>University of Kent</organization>
+    </author>
+   <date day="15" month="Aug" year="2023"/>
+  </front>
+</reference>
+
+<reference anchor="DI" target="https://w3c.github.io/vc-data-integrity/">
+  <front>
+    <title>Verifiable Credential Data Integrity 1.0</title>
+    <author fullname="Manu Sporny">
+      <organization>Digital Bazaar</organization>
+    </author>
+    <author fullname="Dave Longley">
+      <organization>Digital Bazaar</organization>
+    </author>
+    <author fullname="Greg Bernstein">
+      <organization>Invited Expert</organization>
+    </author>
+    <author fullname="Dmitri Zagidulin">
+      <organization>Invited Expert</organization>
+    </author>
+    <author fullname="Sebastian Crane">
+      <organization>Invited Expert</organization>
+    </author>
+   <date day="31" month="Aug" year="2023"/>
+  </front>
+</reference>
+
 <reference anchor="RFC6750" target="https://www.rfc-editor.org/rfc/rfc6750">
   <front>
     <title>The OAuth 2.0 Authorization Framework: Bearer Token Usage</title>
@@ -1787,6 +1893,10 @@ The following additional claims are defined for this Credential format to be add
 The following is a non-normative example of a Credential Offer of type `ldp_vc`:
 
 <{{examples/credential_offer_ldp_vc.json}}
+
+For better suiting the W3C Data Integrity Proof ecosystem the following non-normative example displays a credential request with the proof of posession type `ldp_vp` which uses a verifiable presentation.
+
+<{{examples/credential_request_ldp_vc_vp.json}}
 
 #### Authorization Details {#authorization_ldp_vc}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1895,9 +1895,6 @@ The following is a non-normative example of a Credential Offer of type `ldp_vc`:
 
 <{{examples/credential_offer_ldp_vc.json}}
 
-For better suiting the W3C Data Integrity Proof ecosystem the following non-normative example displays a Credential request with the proof of possession type set to `ldp_vp`, using a verifiable presentation.
-
-<{{examples/credential_request_ldp_vc_vp.json}}
 
 #### Authorization Details {#authorization_ldp_vc}
 
@@ -1924,6 +1921,10 @@ The following additional parameters are defined for Credential Requests and this
 The following is a non-normative example of a Credential Request with Credential format `ldp_vc`:
 
 <{{examples/credential_request_ldp_vc.json}}
+
+For better suiting the W3C Data Integrity Proof ecosystem the following non-normative example displays a Credential request with the proof of possession type set to `ldp_vp`, using a verifiable presentation.
+
+<{{examples/credential_request_ldp_vc_vp.json}}
 
 #### Credential Response
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -769,7 +769,7 @@ This specification defines the following values for the `proof_type` property:
 
 * `jwt`: A JWT [@!RFC7519] is used as proof of possession. When `proof_type` is `jwt`, a `proof` object MUST include a `jwt` claim containing a JWT defined in (#jwt-proof-type).
 * `cwt`: A CWT [@!RFC8392] is used as proof of possession. When `proof_type` is `cwt`, a `proof` object MUST include a `cwt` claim containing a CWT defined in (#cwt-proof-type).
-* `ldp_vp`: A verifiable presentation signed using the Data Integrity Proof defined in [@VC_DATA_2.0] or [@VC_DATA], and where the proof of possession MUST be done in accordance with [@Data_Integrity]. When `proof_type` is set to `ldp_vp`, the `proof` object MUST include a `ldp_vp` claim containing a [verifiable presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
+* `ldp_vp`: A W3C Verifiable Presentation object signed using the Data Integrity Proof as defined in [@VC_DATA_2.0] or [@VC_DATA], and where the proof of possession MUST be done in accordance with [@Data_Integrity]. When `proof_type` is set to `ldp_vp`, the `proof` object MUST include a `ldp_vp` claim containing a [W3C Verifiable Presentation](https://www.w3.org/TR/vc-data-model-2.0/#presentations-0) defined in (#ldp_vp-proof-type).
 
 #### `jwt` Key Proof Type {#jwt-proof-type}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1894,7 +1894,7 @@ The following is a non-normative example of a Credential Offer of type `ldp_vc`:
 
 <{{examples/credential_offer_ldp_vc.json}}
 
-For better suiting the W3C Data Integrity Proof ecosystem the following non-normative example displays a credential request with the proof of posession type `ldp_vp` which uses a verifiable presentation.
+For better suiting the W3C Data Integrity Proof ecosystem the following non-normative example displays a Credential request with the proof of possession type set to `ldp_vp`, using a verifiable presentation.
 
 <{{examples/credential_request_ldp_vc_vp.json}}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -804,7 +804,7 @@ Here is another example JWT not only proving possession of a private key but als
 The verifiable presentation as defined by [@VC_DATA_2.0] signed using Data Integrity that are used as Key Proofs MUST contain the following elements:
 
   * in the presentation itself,
-      * `holder`: OPTIONAL. MUST be equivalent to the DID in the `proof.verificationMethod` property.
+      * `holder`: OPTIONAL. MUST be equivalent to the verificationMethod identifier (e.g. DID) in the `proof.verificationMethod` property.
 
   * in the proof body, 
       * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -810,7 +810,7 @@ The verifiable presentation as defined by [@VC_DATA_2.0] signed using Data Integ
       * `domain`: REQUIRED (string). The value of this claim MUST be the Credential Issuer Identifier.
       * `challenge`: REQUIRED (string). The value type of this claim MUST be a string, where the value is a server-provided `c_nonce`. It MUST be present when the Wallet received server-provided `c_nonce`.
 
-The Credential Issuer MUST validate that the `proof` is actually signed by a key of the holder.
+The Credential Issuer MUST validate that the `proof` is actually signed with a key in possession of the Holder.
 
 Below is a non-normative example of a `proof` parameter:
 


### PR DESCRIPTION
Added a linked data proof type for the proof of possession in the OID4VCI flow

Original PR: https://bitbucket.org/openid/connect/pull-requests/487/add-ldp_vp-as-proof-of-possession