### PR TITLE
make the guidance to request subset of claims format agnostic

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1326,9 +1326,11 @@ To sender-constrain Access Tokens, see the recommendations in Section 4.10.1 in 
 
 # Privacy Considerations
 
-## Wallet Requesting the Subset of the Claims
+## Data Minimization in the Issued Credential
 
-It is on purpose that the Credential Offer does not contain `credentialSubject` nor `claims` properties, while Authorization Details and Credential Request do. This is because this property is meant to be used by the Wallet to specify which claims it is requesting to be issued out of all the claims the Credential Issuer is capable of issuing for this particular Credential (data minimization), while Credential Offer is a mere "invitation" from the Credential Issuer to the Wallet to start the issuance flow.
+It is on purpose that the Credential Offer does not contain `credentialSubject` nor `claims` properties (other Credential Format Profiles may define other values for this property), while Authorization Details and Credential Request do. This is because these properties are meant to be used by the Wallet to specify which claims it is requesting to be issued out of all the claims the Credential Issuer is capable of issuing for this particular credential. Credential Offer is a mere "invitation" from the Credential Issuer to the Wallet to start the issuance flow.
+
+The Wallet MUST NOT use these properties to request claims that are not part of the claims contained in a particular credential type.
 
 {backmatter}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1328,9 +1328,9 @@ To sender-constrain Access Tokens, see the recommendations in Section 4.10.1 in 
 
 ## Data Minimization in the Issued Credential
 
-It is on purpose that the Credential Offer does not contain `credentialSubject` nor `claims` properties (other Credential Format Profiles may define other values for this property), while Authorization Details and Credential Request do. This is because these properties are meant to be used by the Wallet to specify which claims it is requesting to be issued out of all the claims the Credential Issuer is capable of issuing for this particular credential. Credential Offer is a mere "invitation" from the Credential Issuer to the Wallet to start the issuance flow.
+It is on purpose that the Credential Offer does not contain `credentialSubject` nor `claims` properties (other Credential Format Profiles may define other names for this property), while Authorization Details and Credential Request do. This is because these properties are meant to be used by the Wallet to specify which claims it is requesting to be issued out of all the claims the Credential Issuer is capable of issuing for this particular credential. Credential Offer is a mere "invitation" from the Credential Issuer to the Wallet to start the issuance flow.
 
-The Wallet MUST NOT use these properties to request claims that are not part of the claims contained in a particular credential type.
+The Wallet MUST NOT use these properties to request claims that are not part of the claims contained in a particular credential type or claims not authorized by the respective Access Token (in case of a Credential Request).
 
 {backmatter}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1326,7 +1326,9 @@ To sender-constrain Access Tokens, see the recommendations in Section 4.10.1 in 
 
 # Privacy Considerations
 
-TBD
+## Wallet Requesting the Subset of the Claims
+
+It is on purpose that the Credential Offer does not contain `credentialSubject` nor `claims` properties, while Authorization Details and Credential Request do. This is because this property is meant to be used by the Wallet to specify which claims it is requesting to be issued out of all the claims the Credential Issuer is capable of issuing for this particular Credential (data minimization), while Credential Offer is a mere "invitation" from the Credential Issuer to the Wallet to start the issuance flow.
 
 {backmatter}
 
@@ -1671,8 +1673,6 @@ This specification therefore differentiates the following three Credential forma
 Note: VCs secured using Data Integrity MAY NOT necessarily use JSON-LD and MAY NOT necessarily use proof suites requiring Linked Data canonicalization. Credential Format Profiles for them may be defined in the future versions of this specification.
 
 Distinct Credential format identifiers, extension parameters/claims, and processing rules are defined for each of the above-mentioned Credential formats.
-
-It is on purpose that the Credential Offer does not contain `credentialSubject` property, while Authorization Details and Credential Request do. This is because this property is meant to be used by the Wallet to specify which claims it is requesting to be issued out of all the claims the Credential Issuer is capable of issuing for this particular Credential (data minimization), while Credential Offer is a mere "invitation" from the Credential Issuer to the Wallet to start the issuance flow.
 
 ### VC Signed as a JWT, Not Using JSON-LD {#vc-jwt}
 


### PR DESCRIPTION
based on the comment here: https://github.com/vcstuff/oid4vc-haip-sd-jwt-vc/pull/56#issuecomment-1635190840

clarifying that only the subset of claims can be requested using `credentialSubject` and `claims` parameters