### PR TITLE
remove out-dated type limitation for tx_code. make tx_code description consistent.

### DIFF
--- a/examples/credential_offer_multiple_credentials.json
+++ b/examples/credential_offer_multiple_credentials.json
@@ -10,7 +10,7 @@
          "tx_code" : {
             "length": 4,
             "input_mode" : "numeric",
-            "description": "Please provide the transaction code which was sent via e-mail"
+            "description": "Please provide the one-time code which was sent via e-mail"
          }
       }
    }

--- a/examples/credential_offer_multiple_credentials.json
+++ b/examples/credential_offer_multiple_credentials.json
@@ -10,7 +10,7 @@
          "tx_code" : {
             "length": 4,
             "input_mode" : "numeric",
-            "description": "Please provide the transcation code which was sent via e-mail"
+            "description": "Please provide the transaction code which was sent via e-mail"
          }
       }
    }

--- a/examples/credential_offer_multiple_credentials.json
+++ b/examples/credential_offer_multiple_credentials.json
@@ -10,7 +10,7 @@
          "tx_code" : {
             "length": 4,
             "input_mode" : "numeric",
-            "description": "Please provide the one-time code which was sent via e-mail"
+            "description": "Please provide the transcation code which was sent via e-mail"
          }
       }
    }

--- a/examples/credential_offer_pre-authz_code.json
+++ b/examples/credential_offer_pre-authz_code.json
@@ -7,7 +7,7 @@
         "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
             "pre-authorized_code": "adhjhdjajkdkhjhdj",
             "tx_code" : {
-               "description" : "Please provide the transcation code which was sent to your mobile phone via SMS"
+               "description" : "Please provide the one-time code which was sent to your mobile phone via SMS"
             }
         }
     }

--- a/examples/credential_offer_pre-authz_code.json
+++ b/examples/credential_offer_pre-authz_code.json
@@ -7,7 +7,7 @@
         "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
             "pre-authorized_code": "adhjhdjajkdkhjhdj",
             "tx_code" : {
-               "description" : "Enter the PIN which was send by SMS to your mobile phone"
+               "description" : "Please provide the transcation code which was sent to your mobile phone via SMS"
             }
         }
     }

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -562,7 +562,7 @@ Upon receiving a successful Authorization Response, a Token Request is made as d
 The following are the extension parameters to the Token Request used in a Pre-Authorized Code Flow defined by this specification:
 
 * `pre-authorized_code`: The code representing the authorization to obtain Credentials of a certain type. This parameter MUST be present if the `grant_type` is `urn:ietf:params:oauth:grant-type:pre-authorized_code`.
-* `tx_code`: OPTIONAL. String value containing a Transaction Code. This value MUST be present if a `tx_code` object was present in the Credential Offer (including if the object was empty). The string value MUST consist of a maximum of eight numeric characters (the numbers 0 - 9). This parameter MUST only be used if the `grant_type` is `urn:ietf:params:oauth:grant-type:pre-authorized_code`.
+* `tx_code`: OPTIONAL. String value containing a Transaction Code. This value MUST be present if a `tx_code` object was present in the Credential Offer (including if the object was empty). This parameter MUST only be used if the `grant_type` is `urn:ietf:params:oauth:grant-type:pre-authorized_code`.
 
 Requirements around how the Wallet identifies and, if applicable, authenticates itself with the Authorization Server in the Token Request depends on the Client type defined in Section 2.1 of [@!RFC6749] and the Client authentication method indicated in the `token_endpoint_auth_method` Client metadata. The requirement as described in Sections 4.1.3 and 3.2.1 of [@!RFC6749] MUST be followed.
 


### PR DESCRIPTION
tx_code limitation to eight numeric characters is outdated. input_mode text was introduced for tx_code.
Consistent naming of transaction code. Neither pin nor one-time code

Note: The pin is still mentioned in two diagrams:
- [attestation_native_app_issuer_initiated_bff.plantuml](https://github.com/openid/OpenID4VCI/blob/main/diagrams/attestation_native_app_issuer_initiated_bff.plantuml)
- [attestation_native_app_issuer_initiated_client_assertion.plantuml](https://github.com/openid/OpenID4VCI/blob/main/diagrams/attestation_native_app_issuer_initiated_client_assertion.plantuml)

Should this also be fixed?