### PR TITLE
fix: proof_types in non-normative examples

### DIFF
--- a/examples/credential_issuer_metadata_jwt_vc_json.json
+++ b/examples/credential_issuer_metadata_jwt_vc_json.json
@@ -56,7 +56,7 @@
                     }
                 }
             },
-            "proof_types_supported": [
+            "proof_types": [
                 "jwt"
             ],
             "display": [

--- a/examples/credential_metadata_jwt_vc_json.json
+++ b/examples/credential_metadata_jwt_vc_json.json
@@ -42,7 +42,7 @@
                     }
                 }
             },
-            "proof_types_supported": [
+            "proof_types": [
                 "jwt"
             ],
             "display": [


### PR DESCRIPTION
According to https://github.com/openid/OpenID4VCI/commit/32c146c618957cd478bf191f6ad53aaac559e1bc and the current text in the document, I found two non-normative examples to be fixed.

 