### PR TITLE
Remove credentials_supported_identifier from mdoc metadata example

### DIFF
--- a/examples/credential_metadata_mso_mdoc.json
+++ b/examples/credential_metadata_mso_mdoc.json
@@ -3,7 +3,6 @@
         "org.iso.18013.5.1.mDL": {
             "format": "mso_mdoc",
             "doctype": "org.iso.18013.5.1.mDL",
-            "credentials_supported_identifier": "org.iso.18013.5.1.mDL",
             "cryptographic_binding_methods_supported": [
                 "mso"
             ],


### PR DESCRIPTION
This is the only mention of credentials_supported_identifier in the whole specification, I believe this was just overlooked in https://github.com/openid/OpenID4VCI/pull/86