### PR TITLE
Fix Japanese text in examples

### DIFF
--- a/examples/credential_metadata_mso_mdoc.json
+++ b/examples/credential_metadata_mso_mdoc.json
@@ -16,17 +16,17 @@
                     "locale": "en-US",
                     "logo": {
                         "url": "https://state.example.org/public/mdl.png",
-                        "alt_text": "a square figure of a mobile driving license"
+                        "alt_text": "state mobile driving license"
                     },
                     "background_color": "#12107c",
                     "text_color": "#FFFFFF"
                 },
                 {
-                    "name": "在籍証明書",
+                    "name": "モバイル運転免許証",
                     "locale": "ja-JP",
                     "logo": {
                         "url": "https://state.example.org/public/mdl.png",
-                        "alt_text": "大学のロゴ"
+                        "alt_text": "米国州発行のモバイル運転免許証"
                     },
                     "background_color": "#12107c",
                     "text_color": "#FFFFFF"


### PR DESCRIPTION
Thanks to Kosuke Koiwai from KDDI for help with the translations.

I also updated the English alt text as it is not considered good practice to include 'figure of' in the alt text as screen readers for the blind etc already know it is an image.

Fixes part of #172