### PR TITLE
rename credential_configurations to credential_configuration_ids

### DIFF
--- a/examples/credential_offer_authz_code.txt
+++ b/examples/credential_offer_authz_code.txt
@@ -3,7 +3,7 @@ Content-Type: application/json
 
 {
     "credential_issuer": "https://credential-issuer.example.com",
-    "credential_configurations": [
+    "credential_configuration_ids": [
         "UniversityDegreeCredential"
     ],
     "grants": {

--- a/examples/credential_offer_by_reference.json
+++ b/examples/credential_offer_by_reference.json
@@ -1,6 +1,6 @@
 {
    "credential_issuer": "https://credential-issuer.example.com",
-   "credential_configurations": [
+   "credential_configuration_ids": [
       "UniversityDegree_LDP_VC"
    ],
    "grants": {

--- a/examples/credential_offer_multiple_credentials.json
+++ b/examples/credential_offer_multiple_credentials.json
@@ -1,6 +1,6 @@
 {
    "credential_issuer": "https://credential-issuer.example.com",
-   "credential_configurations": [
+   "credential_configuration_ids": [
       "UniversityDegreeCredential",
       "org.iso.18013.5.1.mDL"
    ],

--- a/examples/credential_offer_pre-authz_code.json
+++ b/examples/credential_offer_pre-authz_code.json
@@ -1,6 +1,6 @@
 {
     "credential_issuer": "https://credential-issuer.example.com",
-    "credential_configurations": [
+    "credential_configuration_ids": [
         "UniversityDegreeCredential"
     ],
     "grants": {

--- a/examples/credential_offer_sd_jwt_vc.json
+++ b/examples/credential_offer_sd_jwt_vc.json
@@ -1,6 +1,6 @@
 {
     "credential_issuer": "https://credential-issuer.example.com",
-    "credentials": [
+    "credential_configuration_ids": [
         "SD_JWT_VC_example_in_OpenID4VCI"
     ],
     "grants": {

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -324,7 +324,7 @@ For security considerations, see (#credential-offer-security).
 This specification defines the following parameters for the JSON-encoded Credential Offer object:
 
 * `credential_issuer`: REQUIRED. The URL of the Credential Issuer, as defined in (#credential_issuer_identifier), from which the Wallet is requested to obtain one or more Credentials. The Wallet uses it to obtain the Credential Issuer's Metadata following the steps defined in (#credential_issuer_wellknown).
-* `credential_configurations`: REQUIRED. Array of unique strings that each identify one of the keys in the name/value pairs stored in the `credential_configurations_supported` Credential Issuer metadata. The Wallet uses these string values to obtain the respective object that contains information about the Credential being offered as defined in (#credential-issuer-parameters). For example, these string values can be used to obtain `scope` values to be used in the Authorization Request.
+* `credential_configuration_ids`: REQUIRED. Array of unique strings that each identify one of the keys in the name/value pairs stored in the `credential_configurations_supported` Credential Issuer metadata. The Wallet uses these string values to obtain the respective object that contains information about the Credential being offered as defined in (#credential-issuer-parameters). For example, these string values can be used to obtain `scope` values to be used in the Authorization Request.
 * `grants`: OPTIONAL. Object indicating to the Wallet the Grant Types the Credential Issuer's Authorization Server is prepared to process for this Credential Offer. Every grant is represented by a name/value pair. The name is the Grant Type identifier; the value is an object that contains parameters either determining the way the Wallet MUST use the particular grant and/or parameters the Wallet MUST send with the respective request(s). If `grants` is not present or is empty, the Wallet MUST determine the Grant Types the Credential Issuer's Authorization Server supports using the respective metadata. When multiple grants are present, it is at the Wallet's discretion which one to use.
 
 The following values are defined by this specification: 
@@ -449,7 +449,7 @@ Note: Applications MAY combine authorization details of type `openid_credential`
 
 In addition to a mechanism defined in (#credential-authz-request), Credential Issuers MAY support requesting authorization to issue a Credential using the OAuth 2.0 `scope` parameter.
 
-When the Wallet does not know which scope value to use to request issuance of a certain Credential, it can discover it using the `scope` Credential Issuer metadata parameter defined in (#credential-issuer-parameters). When the flow starts with a Credential Offer, the Wallet can use the `credential_configurations` parameter values to identify object(s) in the `credential_configurations_supported` map in the Credential Issuer metadata parameter and use the `scope` parameter value from that object.
+When the Wallet does not know which scope value to use to request issuance of a certain Credential, it can discover it using the `scope` Credential Issuer metadata parameter defined in (#credential-issuer-parameters). When the flow starts with a Credential Offer, the Wallet can use the `credential_configuration_ids` parameter values to identify object(s) in the `credential_configurations_supported` map in the Credential Issuer metadata parameter and use the `scope` parameter value from that object.
 
 The Wallet can discover the scope values using other options such as normative text in a profile of this specification that defines scope values along with a description of their semantics.
 
@@ -2291,7 +2291,7 @@ Wallet Providers may also provide a marketplace where Issuers can register to be
    * clarified description of a `mandatory` claim
    * made sure to use gender-neutral language throughout the specification
    * changed `authorization_details` to use `credential_configuration_id` pointing to the name of a `credential_configurations_supported` object in the Credential Issuer's Metadata
-   * renamed `credentials` Credential Offer parameter to `credential_configurations`
+   * renamed `credentials` Credential Offer parameter to `credential_configuration_ids`
    * renamed `credentials_supported` Credential Issuer metadata parameter to `credential_configurations_supported`
    * grouped `credential_encryption_jwk`, `credential_response_encryption_alg` and `credential_response_encryption_enc` from Credential Request into a single `credential_response_encryption` object
    * replaced `user_pin_required` in Credential Offer with a `tx_code` object that also now contains `description` and `length`


### PR DESCRIPTION
aligning with `credential_configuration_id` in authorization details. resolves #221 