### PR TITLE
Remove the duplicate requirement about not including query parameters to Credential Issuer Identifier

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1316,7 +1316,7 @@ Credential Issuers publishing metadata MUST make a JSON document available at th
 
 Communication with the Credential Issuer Metadata Endpoint MUST utilize TLS.
 
-To fetch the Credential Issuer Metadata, the requester MUST send an HTTP request using the GET method and the path formed following the steps above. The URL SHOULD NOT contain any query parameters. The Credential Issuer MUST return a JSON document compliant with this specification using the `application/json` media type and the HTTP Status Code 200.
+To fetch the Credential Issuer Metadata, the requester MUST send an HTTP request using the GET method and the path formed following the steps above. The Credential Issuer MUST return a JSON document compliant with this specification using the `application/json` media type and the HTTP Status Code 200.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 


### PR DESCRIPTION
A Credential Issuer URL should not already include the query component per 11.2.2.

If an intent for the wallet was to not add any query parameters to the Credential Issuer Identifier when it fetches the metadata then this sentence should be changed to better reflect this.