### PR TITLE
Add a note about the known limitations of the credential claim metadata

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1995,6 +1995,15 @@ The following additional Credential Issuer metadata parameters are defined for t
           * `locale`: OPTIONAL. String value that identifies language of this object represented as language tag values defined in BCP47 [@!RFC5646]. There MUST be only one object for each language identifier.
 * `order`: OPTIONAL. Array of the claim name values that lists them in the order they should be displayed by the Wallet.
 
+> The above metadata structure has some known limitations:
+>
+> * It cannot be used to describe claims in credentials that have the name `mandatory`, `value_type` or `display`.
+> * It is not possible to provide `mandatory`, `value_type` or `display` values for objects that contain claims 
+> * The `order` parameter cannot be used for claims within objects
+> * Arrays of unknown size cannot be described
+>
+> These limitations are expected to be resolved in the second Implementer's Draft, a proposal can be viewed in [Issue 266](https://github.com/openid/OpenID4VCI/issues/266).
+
 The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential format `jwt_vc_json`:
 
 <{{examples/credential_metadata_jwt_vc_json.json}}
@@ -2060,6 +2069,14 @@ The following additional Credential Issuer metadata parameters are defined for t
           * `locale`: OPTIONAL. String value that identifies language of this object represented as language tag values defined in BCP47 [@!RFC5646]. There MUST be only one object for each language identifier.
 * `order`: OPTIONAL. Array of the claim name values that lists them in the order they should be displayed by the Wallet.
 
+> The above metadata structure has some known limitations:
+>
+> * It cannot be used to describe claims in credentials that have the name `mandatory`, `value_type` or `display`.
+> * It is not possible to provide `mandatory`, `value_type` or `display` values for objects that contain claims
+> * The `order` parameter cannot be used for claims within objects
+> * Arrays of unknown size cannot be described
+>
+> These limitations are expected to be resolved in the second Implementer's Draft, a proposal can be viewed in [Issue 266](https://github.com/openid/OpenID4VCI/issues/266).
 
 The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential format `ldp_vc`:
 
@@ -2205,6 +2222,15 @@ The following additional Credential Issuer metadata parameters are defined for t
         * `name`: OPTIONAL. String value of a display name for the claim.
         * `locale`: OPTIONAL. String value that identifies language of this object represented as language tag values defined in BCP47 [@!RFC5646]. There MUST be only one object for each language identifier.
 * `order`: OPTIONAL. An array of the claim name values that lists them in the order they should be displayed by the Wallet.
+
+> The above metadata structure has some known limitations:
+>
+> * It cannot be used to describe claims in credentials that have the name `mandatory`, `value_type` or `display`.
+> * It is not possible to provide `mandatory`, `value_type` or `display` values for objects that contain claims
+> * The `order` parameter cannot be used for claims within objects
+> * Arrays of unknown size cannot be described
+>
+> These limitations are expected to be resolved in the second Implementer's Draft, a proposal can be viewed in [Issue 266](https://github.com/openid/OpenID4VCI/issues/266).
 
 The following is a non-normative example of an object comprising the `credential_configurations_supported` parameter for Credential format `vc+sd-jwt`.
 


### PR DESCRIPTION
As discussed on yesterday's working group call:

https://github.com/openid/OpenID4VCI/issues/266#issuecomment-1967533918

As it seems likely that https://github.com/openid/OpenID4VCI/pull/276 will not make it into implementer's draft 1, we instead add warnings about the known limitations of the current data structure so that implementer's are aware.

Note that I have not applied this to the mdoc profile section, as that sections seems not to allow nested objects in the metadata.