### PR TITLE
Change token endpoint example to use private_key_jwt

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -579,12 +579,13 @@ Below is a non-normative example of a Token Request in an Authorization Code Flo
 POST /token HTTP/1.1
 Host: server.example.com
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
 
 grant_type=authorization_code
 &code=SplxlOBeZQQYbYS6WxSbIA
 &code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-&redirect_uri=https%3A%2F%2FWallet.example.org%2Fcb  
+&redirect_uri=https%3A%2F%2FWallet.example.org%2Fcb
+&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
+&client_assertion=eyJhbGciOiJSU...
 ```
 
 Below is a non-normative example of a Token Request in a Pre-Authorized Code Flow (without Client Authentication):


### PR DESCRIPTION
As per discussion on the issue, client secret based authentication methods aren't the best choice for an example in the VCI spec as it seems highly unlikely wallets will use client secrets to authenticate to issuers.

Switch to using a private_key_jwt in the example instead, copied from the example in the RFC:

https://datatracker.ietf.org/doc/html/rfc7523#section-2.2

This was the only instance of client secret basic in the whole spec.

closes #130