### PR TITLE
Fix `uri` field name in `logo` objects in examples

### DIFF
--- a/examples/credential_issuer_metadata_jwt_vc_json.json
+++ b/examples/credential_issuer_metadata_jwt_vc_json.json
@@ -77,7 +77,7 @@
                     "name": "University Credential",
                     "locale": "en-US",
                     "logo": {
-                        "url": "https://university.example.edu/public/logo.png",
+                        "uri": "https://university.example.edu/public/logo.png",
                         "alt_text": "a square logo of a university"
                     },
                     "background_color": "#12107c",

--- a/examples/credential_metadata_jwt_vc_json.json
+++ b/examples/credential_metadata_jwt_vc_json.json
@@ -54,7 +54,7 @@
                     "name": "University Credential",
                     "locale": "en-US",
                     "logo": {
-                        "url": "https://university.example.edu/public/logo.png",
+                        "uri": "https://university.example.edu/public/logo.png",
                         "alt_text": "a square logo of a university"
                     },
                     "background_color": "#12107c",

--- a/examples/credential_metadata_ldp_vc.json
+++ b/examples/credential_metadata_ldp_vc.json
@@ -58,7 +58,7 @@
                     "name": "University Credential",
                     "locale": "en-US",
                     "logo": {
-                        "url": "https://university.example.edu/public/logo.png",
+                        "uri": "https://university.example.edu/public/logo.png",
                         "alt_text": "a square logo of a university"
                     },
                     "background_color": "#12107c",

--- a/examples/credential_metadata_mso_mdoc.json
+++ b/examples/credential_metadata_mso_mdoc.json
@@ -14,7 +14,7 @@
                     "name": "Mobile Driving License",
                     "locale": "en-US",
                     "logo": {
-                        "url": "https://state.example.org/public/mdl.png",
+                        "uri": "https://state.example.org/public/mdl.png",
                         "alt_text": "state mobile driving license"
                     },
                     "background_color": "#12107c",
@@ -24,7 +24,7 @@
                     "name": "モバイル運転免許証",
                     "locale": "ja-JP",
                     "logo": {
-                        "url": "https://state.example.org/public/mdl.png",
+                        "uri": "https://state.example.org/public/mdl.png",
                         "alt_text": "米国州発行のモバイル運転免許証"
                     },
                     "background_color": "#12107c",


### PR DESCRIPTION
Per the definition of the data structure that this example shows, the `logo` of the display properties of a Credential should have an `uri` field instead of `url` field.