### PR TITLE
fix ldp_vc issuer metadata example

### DIFF
--- a/examples/credential_metadata_ldp_vc.json
+++ b/examples/credential_metadata_ldp_vc.json
@@ -2,14 +2,6 @@
     "credential_configurations_supported": {
         "UniversityDegree_LDP_VC": {
             "format": "ldp_vc",
-            "@context": [
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1"
-            ],
-            "type": [
-                "VerifiableCredential",
-                "UniversityDegreeCredential"
-            ],
             "cryptographic_binding_methods_supported": [
                 "did:example"
             ],


### PR DESCRIPTION
remove '@context' and 'type' attributes from top level issuer metadata document for ldp_vc credential format as these two have been moved to 'credential_definition' structure