### PR TITLE
Change working group to DCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Specification to allow holders to request issuance of credentials and issuers to
 
 The current WG-Draft version is built automatically from the master branch and can be accessed at: https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html
 
+Other versions of the spec can be accessed at: https://openid.net/sg/openid4vc/specifications/
+
 ### Build the HTML ###
 
 ```docker run -v `pwd`:/data danielfett/markdown2rfc openid-4-verifiable-credential-issuance-1_0.md```

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2,7 +2,7 @@
 title = "OpenID for Verifiable Credential Issuance - Editor's draft"
 abbrev = "openid-4-verifiable-credential-issuance"
 ipr = "none"
-workgroup = "OpenID Connect"
+workgroup = "OpenID Digital Credentials Protocols"
 keyword = ["security", "openid", "ssi"]
 
 [seriesInfo]


### PR DESCRIPTION
As per adoption call on mailing list:

https://lists.openid.net/pipermail/openid-specs-digital-credentials-protocols/Week-of-Mon-20240415/000259.html

Also update README to link to somewhere other versions (like implementer's drafts) of the specification can be found. (I chose to link to this page rather than linking directly to the latest implementer's draft etc so that we have fewer places listing the same info so that we have fewer places to try and keep up to date.)