### PR TITLE
removing invalid_scope definition

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -561,8 +561,6 @@ Location: https://Wallet.example.org/cb?
 
 The Authorization Error Response MUST be made as defined in [@!RFC6749].
 
-When the requested scope value is invalid, unknown, or malformed, the Authorization Server should respond with the error code `invalid_scope` defined in Section 4.1.2.1 of [@!RFC6749].
-
 Below is a non-normative example of an unsuccessful Authorization Response.
 
 ```json=


### PR DESCRIPTION
resolves #296.

I am not sure why we have `invalid_scope` error parameter singled out given that it's one of the error codes already covered by a sentence "The Authorization Error Response MUST be made as defined in [RFC6749](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html#RFC6749)." unless anyone can remember the reason, removing `invalid_scope` text sounds like the simplest way to clarify.