### PR TITLE
Fixes #287; Clarify mso_mdoc credential response and add example

### DIFF
--- a/examples/credential_response_mso_mdoc.txt
+++ b/examples/credential_response_mso_mdoc.txt
@@ -1,0 +1,7 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Cache-Control: no-store
+
+{
+  "credential": "omppc3N1ZXJBdXRohEOhASahG...ArQwggKwMIICVqADAgEC"
+}

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2266,7 +2266,11 @@ The following is a non-normative example of a Credential Request with Credential
 
 ### Credential Response
 
-The value of the `credential` claim in the Credential Response MUST be a string that is the base64url-encoded representation of the issued Credential.
+The value of the `credential` claim in the Credential Response MUST be a string that is the base64url-encoded representation of the CBOR-encoded `IssuerSigned` structure, as defined in [@!ISO.18013-5].
+
+The following is a non-normative example of a Credential Response containing a Credential of format `mso_mdoc`.
+
+<{{examples/credential_response_mso_mdoc.txt}}
 
 ## IETF SD-JWT VC
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2266,7 +2266,7 @@ The following is a non-normative example of a Credential Request with Credential
 
 ### Credential Response
 
-The value of the `credential` claim in the Credential Response MUST be a string that is the base64url-encoded representation of the CBOR-encoded `IssuerSigned` structure, as defined in [@!ISO.18013-5].
+The value of the `credential` claim in the Credential Response MUST be a string that is the base64url-encoded representation of the CBOR-encoded `IssuerSigned` structure, as defined in [@!ISO.18013-5]. This structure SHOULD contain all `Namespaces` and `IssuerSignedItems` that are included in the `AuthorizedNamespaces` of the `MobileSecurityObject`.
 
 The following is a non-normative example of a Credential Response containing a Credential of format `mso_mdoc`.
 


### PR DESCRIPTION
This PR fixes #287 by clarifying the expected credential response for mso_mdoc as well as adding a shortened example. A full example would be too long.