### PR TITLE
Clarify language around opening Credential Offer Endpoint

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -333,7 +333,7 @@ This endpoint is used by a Credential Issuer that is already interacting with an
 
 ## Credential Offer {#credential-offer}
 
-The Credential Issuer makes a Credential Offer by allowing the End-User to invoke the Wallet using the Wallet's Credential Offer Endpoint defined in (#client-metadata) (for example by clicking a link) and/or rendering a QR code containing the Credential Offer that the End-User can scan in a wallet or an arbitrary camera application.
+The Credential Issuer makes a Credential Offer by allowing the End-User to invoke the Wallet using the Wallet's Credential Offer Endpoint defined in (#client-metadata). For example, by clicking a link and/or rendering a QR code containing the Credential Offer that the End-User can scan in a wallet or an arbitrary camera application.
 
 Credential Issuers MAY also communicate Credential Offers directly to a Wallet's backend but any mechanism for doing so is currently outside the scope of this specification.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -334,7 +334,7 @@ This endpoint is used by a Credential Issuer that is already interacting with an
 ## Credential Offer {#credential-offer}
 
 The Credential Issuer makes a Credential Offer by directing the End-User's
-user-agent to the Wallet's Credential Offer Endpoint defined in (#client-metadata).
+user-agent to the Wallet's Credential Offer Endpoint defined in (#client-metadata). The Credential Issuer MAY render a QR code containing the Credential Offer that can be scanned by the End-User using a Wallet, or a link that the End-User can click.
 
 The Credential Offer object, which is a JSON-encoded object with the Credential Offer parameters, can be sent by value or by reference.
 
@@ -342,8 +342,6 @@ The Credential Offer contains a single URI query parameter, either `credential_o
 
 * `credential_offer`: Object with the Credential Offer parameters. This MUST NOT be present when the `credential_offer_uri` parameter is present.
 * `credential_offer_uri`: String that is a URL using the `https` scheme referencing a resource containing a JSON object with the Credential Offer parameters. This MUST NOT be present when the `credential_offer` parameter is present.
-
-The Credential Issuer MAY render a QR code containing the Credential Offer that can be scanned by the End-User using a Wallet, or a link that the End-User can click.
 
 For security considerations, see (#credential-offer-security).
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -333,7 +333,7 @@ This endpoint is used by a Credential Issuer that is already interacting with an
 
 ## Credential Offer {#credential-offer}
 
-The Credential Issuer makes a Credential Offer by directing the resource owner's
+The Credential Issuer makes a Credential Offer by directing the End-User's
 user-agent to the Wallet's Credential Offer Endpoint defined in (#client-metadata).
 
 The Credential Offer object, which is a JSON-encoded object with the Credential Offer parameters, can be sent by value or by reference.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -333,7 +333,8 @@ This endpoint is used by a Credential Issuer that is already interacting with an
 
 ## Credential Offer {#credential-offer}
 
-The Credential Issuer sends Credential Offer using an HTTP GET request or an HTTP redirect to the Wallet's Credential Offer Endpoint defined in (#client-metadata).
+The Credential Issuer makes a Credential Offer by directing the resource owner's
+user-agent to the Wallet's Credential Offer Endpoint defined in (#client-metadata).
 
 The Credential Offer object, which is a JSON-encoded object with the Credential Offer parameters, can be sent by value or by reference.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -335,6 +335,8 @@ This endpoint is used by a Credential Issuer that is already interacting with an
 
 The Credential Issuer makes a Credential Offer by allowing the End-User to invoke the Wallet using the Wallet's Credential Offer Endpoint defined in (#client-metadata) (for example by clicking a link) and/or rendering a QR code containing the Credential Offer that the End-User can scan in a wallet or an arbitrary camera application.
 
+Credential Issuers MAY also communicate Credential Offers directly to a Wallet's backend but any mechanism for doing so is currently outside the scope of this specification.
+
 The Credential Offer object, which is a JSON-encoded object with the Credential Offer parameters, can be sent by value or by reference.
 
 The Credential Offer contains a single URI query parameter, either `credential_offer` or `credential_offer_uri`:

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -333,8 +333,7 @@ This endpoint is used by a Credential Issuer that is already interacting with an
 
 ## Credential Offer {#credential-offer}
 
-The Credential Issuer makes a Credential Offer by directing the End-User's
-user-agent to the Wallet's Credential Offer Endpoint defined in (#client-metadata). The Credential Issuer MAY render a QR code containing the Credential Offer that can be scanned by the End-User using a Wallet, or a link that the End-User can click.
+The Credential Issuer makes a Credential Offer by allowing the End-User to invoke the Wallet using the Wallet's Credential Offer Endpoint defined in (#client-metadata) (for example by clicking a link) and/or rendering a QR code containing the Credential Offer that the End-User can scan in a wallet or an arbitrary camera application.
 
 The Credential Offer object, which is a JSON-encoded object with the Credential Offer parameters, can be sent by value or by reference.
 


### PR DESCRIPTION
As per consensus on Oct-10-2022 working group call, the credential offer endpoint must be redirected to in order to allow the wallet to have a user interaction.

The languaged used is the same as used in RFC6749, but with resource owner changed to End-User for consistency with rest of VCI spec.

closes #13

closes #201