### PR TITLE
Add clarification about client_id for wallet attestation

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2558,7 +2558,7 @@ The following is a non-normative example of a Wallet Attestation:
 
 To use the Wallet Attestation towards the Authorization Server, the Wallet MUST generate a proof of possession according to Section 5.2 "Client Attestation PoP JWT" of Attestation-Based Client Authentication.
 
-The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. This value should be shared by all Wallet Instances for privacy reasons.
+The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. This value should be shared by all Wallet Instances from that Wallet Provider for privacy reasons.
 
 # IANA Considerations
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2558,7 +2558,7 @@ The following is a non-normative example of a Wallet Attestation:
 
 To use the Wallet Attestation towards the Authorization Server, the Wallet MUST generate a proof of possession according to Section 5.2 "Client Attestation PoP JWT" of Attestation-Based Client Authentication.
 
-The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. This value should be shared by all Wallet Instances from that Wallet Provider for privacy reasons.
+The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. For privacy reasons, this value is the same across Wallet Instances of that Wallet Provider.
 
 # IANA Considerations
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1666,7 +1666,7 @@ history, etc. and correlate the user's activity using it.
 
 ### Wallet Attestation Subject {#walletattestation-sub}
 
-The Wallet Attestation as defined in (#wallet attestation) SHOULD NOT introduce a unique identifier specific to a single client.
+The Wallet Attestation as defined in (#walletattestation) SHOULD NOT introduce a unique identifier specific to a single client.
 The subject claim for the Wallet Attestation SHOULD be a value that is shared by all Wallet instances using this type of
 wallet implementation. The value should be understood as an identifier of the Wallet type, rather than the specific Wallet
 instance itself.
@@ -2565,7 +2565,7 @@ The following is a non-normative example of a Wallet Attestation:
 
 To use the Wallet Attestation towards the Authorization Server, the Wallet MUST generate a proof of possession according to Section 5.2 "Client Attestation PoP JWT" of Attestation-Based Client Authentication.
 
-The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. For privacy reasons, this value is the same across Wallet instances of that Wallet Provider, see (#walletattestation-sub) for more details.
+The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet instance. For privacy reasons, this value is the same across Wallet instances of that Wallet Provider, see (#walletattestation-sub) for more details.
 
 # IANA Considerations
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2558,6 +2558,8 @@ The following is a non-normative example of a Wallet Attestation:
 
 To use the Wallet Attestation towards the Authorization Server, the Wallet MUST generate a proof of possession according to Section 5.2 "Client Attestation PoP JWT" of Attestation-Based Client Authentication.
 
+The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. This value should be shared by all Wallet Instances for privacy reasons.
+
 # IANA Considerations
 
 ## OAuth URI Registry

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2532,7 +2532,7 @@ The following is a non-normative example of a Wallet Attestation:
 
 ```
 {
-  "typ": "oauth-client-attestation+jwt"
+  "typ": "oauth-client-attestation+jwt",
   "alg": "ES256",
   "kid": "11"
 }

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2758,7 +2758,7 @@ The technology described in this specification was made available from contribut
 
    -16
 
-   *
+   * clarify client_id of wallet with wallet attestation
 
    -15
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1664,6 +1664,13 @@ for example, by including clear-text session information as a `state` parameter 
 it in a `redirect_uri` parameter. A third party may observe such information through browser
 history, etc. and correlate the user's activity using it.
 
+### Wallet Attestation Subject {#walletattestation-sub}
+
+The Wallet Attestation as defined in (#wallet attestation) SHOULD NOT introduce a unique identifier specific to a single client.
+The subject claim for the Wallet Attestation SHOULD be a value that is shared by all Wallet instances using this type of
+wallet implementation. The value should be understood as an identifier of the Wallet type, rather than the specific Wallet
+instance itself.
+
 ## Identifying the Credential Issuer
 
 Information in the credential identifying a particular Credential Issuer, such as a Credential Issuer Identifier,
@@ -2558,7 +2565,7 @@ The following is a non-normative example of a Wallet Attestation:
 
 To use the Wallet Attestation towards the Authorization Server, the Wallet MUST generate a proof of possession according to Section 5.2 "Client Attestation PoP JWT" of Attestation-Based Client Authentication.
 
-The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. For privacy reasons, this value is the same across Wallet Instances of that Wallet Provider.
+The `sub` claim of the Wallet Attestation JWT is picked by the Wallet Provider and represents the `client_id` of the Wallet. For privacy reasons, this value is the same across Wallet instances of that Wallet Provider, see (#walletattestation-sub) for more details.
 
 # IANA Considerations
 
@@ -2758,7 +2765,7 @@ The technology described in this specification was made available from contribut
 
    -16
 
-   * clarify client_id of wallet with wallet attestation
+   * add privacy considerations for the client_id used with wallet attestations
 
    -15
 


### PR DESCRIPTION
Closes #431 

Adds small text sections that explains how `sub` of the Wallet Attestation JWT works and should be chosen