### PR TITLE
wallet-attestation+jwt media registry entry

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2695,7 +2695,7 @@ in the manner described in [@RFC6838].
   * Required parameters: n/a
   * Optional parameters: n/a
   * Encoding considerations: binary; A JWT-based Wallet Attestation object is a JWT; JWT values are encoded as a series of base64url-encoded values (some of which may be the empty string) separated by period ('.') characters.
-  * Security considerations: See (#wallet-attestation-schema) of [[ this specification ]]
+  * Security considerations: See (#walletattestation) of [[ this specification ]]
   * Interoperability considerations: n/a
   * Published specification: [[ this specification ]]
   * Applications that use this media type: Applications using [[ this specification ]] for issuing and validating Wallet Instance Attestations.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2688,6 +2688,28 @@ in the manner described in [@RFC6838].
 * Change controller: OpenID Foundation Digital Credentials Protocols Working Group - openid-specs-digital-credentials-protocols@lists.openid.net
 * Provisional registration? No
 
+### application/wallet-attestation+jwt
+
+  * Type name: application
+  * Subtype name: wallet-attestation+jwt
+  * Required parameters: n/a
+  * Optional parameters: n/a
+  * Encoding considerations: binary; A JWT-based Wallet Attestation object is a JWT; JWT values are encoded as a series of base64url-encoded values (some of which may be the empty string) separated by period ('.') characters.
+  * Security considerations: See (#wallet-attestation-schema) of [[ this specification ]]
+  * Interoperability considerations: n/a
+  * Published specification: [[ this specification ]]
+  * Applications that use this media type: Applications using [[ this specification ]] for issuing and validating Wallet Instance Attestations.
+  * Fragment identifier considerations: n/a
+  * Additional information:
+    * File extension(s): n/a
+    * Macintosh file type code(s): n/a
+  * Person & email address to contact for further information: Torsten Lodderstedt, torsten@lodderstedt.net
+  * Intended usage: COMMON
+  * Restrictions on usage: none
+  * Author: Torsten Lodderstedt
+  * Change controller: IETF
+  * Provisional registration? No
+
 ## Uniform Resource Identifier (URI) Schemes Registry
 
 This specification registers the following URI scheme


### PR DESCRIPTION
This PR adds the media type wallet-attestation+jwt in the media registry of this specification.

It cames from [OpenID HAIP](https://github.com/openid/oid4vc-haip/pull/86#issuecomment-2609703378) as it was asked me to move it to openid4vci.