### PR TITLE
Change Cryptographic Holder Binding to Cryptographic Key Binding

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2757,6 +2757,7 @@ The technology described in this specification was made available from contribut
    -16
 
    *
+   * Change Cryptographic Holder Binding to Cryptographic Key Binding
 
    -15
 


### PR DESCRIPTION
Fixes #26 

The issue described changing Holder Binding to Key Binding, but I don't believe that is correct as there are other ways to bind a credential to a Holder than to use key binding. I therefore updated Cryptographic Holder Binding to Cryptographic Key Binding, which might have been the intent anyway I presume.