### PR TITLE
set nonce in key attestation to c_nonce value for issuance

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -933,6 +933,8 @@ There are two ways to convey key attestations (as defined in (#keyattestation)) 
 - The Wallet uses the `jwt` proof type in the Credential Request to create a proof of possession of the key and adds the key attestation in the JOSE header.
 - The Wallet uses the `attestation` proof type in the Credential Request with the key attestation without a proof of possession of the key itself.
 
+In both cases, the `nonce` value in the key attestation is set to the `c_nonce` value provided by the Issuer.
+
 Depending on the Wallet's implementation, the `attestation` may avoid unnecessary End-User interaction during Credential issuance, as the key itself does not necessarily need to perform signature operations.
 
 Additional proof types MAY be defined and used.
@@ -2796,6 +2798,7 @@ The technology described in this specification was made available from contribut
    * deprecate the proof paramter in the credential request
    * add missing request for media type registration of key-attestation+jwt in IANA Considerations
    * rename keyattestation+jwt to key-attestation+jwt
+   * set key attestation nonce to c_nonce value for proof types with key attestations
 
    -15
 


### PR DESCRIPTION
This PR fixes #438. 

The language was added to the more specific proof type section since the key attestation annex might be referenced by other specs that may or may not use c_nonce. If it is unlikely that other specs would borrow the key attestation annex, I could change the PR, so the c_nonce text is added to the annex instead of the proof types section.