### PR TITLE
Presentation During Issuance

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -902,7 +902,7 @@ Cache-Control: no-store
 }
 ```
 
-Once this phase of the Authorization process is completed, the Authorization Server MUST redirect back to the Wallet as per [@RFC6749]. If the Authorization process is complete when this redirect occurs, the Authorization Server returns a response with the `code` parameter as per Section 1.3.1 of [@RFC6749]. If the Authorization process is not complete when this redirect occurs, the Authorization Server returns a response with the `auth_session` parameter. In the event a Wallet receives a response from the Authorization Server which features the `auth_session` parameter, the Wallet MUST make a follow-up request as per (#follow-up-request) to continue the Authorization process.
+Once this phase of the Authorization process is completed, the Authorization Server MUST redirect back to the Wallet as per [@RFC6749]. If the Authorization process is complete when this redirect occurs, the Authorization Server returns a response with the `code` parameter as per Section 1.3.1 of [@RFC6749].
 
 #### Custom Interaction Extensions {#iar-custom-extensions}
 


### PR DESCRIPTION
First, minimal version of Presentation During Issuance (Issue #473) . Work in Progress.

There are four open todos:

- [x] Determine whether we a way to show a website. The first-part apps draft right now only contains a fallback to the regular web flow, not a flexible way to open an in-app browser tab. If we add something like this, we may need to include privacy considerations.
- [x] The original draft contains a `presentation_during_issuance_session` parameter, for binding the presentation response to the issuance process. Do we need this, and if yes, how do we define it?
- [x] Determine if we want to make the extension point ("define your own responses here for scanning an ID card") explicit or not.
- [x] Add new endpoint / OAuth error / etc to IANA considerations