### PR TITLE
add option to have signed Credential Issuer metadata, remove `signed_metadata` from Credential Issuer metadata

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1433,7 +1433,7 @@ The signed metadata MUST be secured using a JSON Web Signature (JWS) [@!RFC7515]
   * `iat`: REQUIRED. Integer for the time at which the Credential Issuer Metadata was issued using the syntax defined in [@!RFC7519].
   * `exp`: OPTIONAL. Integer for the time at which the Credential Issuer Metadata is expiring, using the syntax defined in [@!RFC7519].
 
-The Wallet SHOULD establish trust in the signer of the metadata, and obtain the keys to validate the signature before processing the metadata, e.g. using JOSE headers like `x5c`, `kid` or `trust_chain` to convey the public key. The concrete mechanism how to do that is out of scope of this specification. 
+The Wallet SHOULD establish trust in the signer of the metadata, and obtain the keys to validate the signature before processing the metadata, e.g. using JOSE header parameters like `x5c`, `kid` or `trust_chain` to convey the public key. The concrete mechanisms how to do that are out of scope of this specification. 
 
 ### Credential Issuer Metadata Parameters {#credential-issuer-parameters}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1263,7 +1263,7 @@ The Credential Issuer MUST respond with HTTP Status Code 200 and return the Cred
 * an unsigned JSON document using the media type `application/json`
 * a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`
 
-The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type`. It is RECOMMENDED to respond with a `Content-Type` matching to the Wallet's requested `Accept` Header. However, the Credential Issuer MAY ignore the `Accept` Header.
+The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` Header. However, the Credential Issuer MAY ignore the `Accept` Header.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1417,7 +1417,7 @@ The Credential Issuer MUST respond with HTTP Status Code 200 and return the Cred
 * an unsigned JSON document using the media type `application/json`
 * a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`
 
-The Credential Issuer is RECOMMENDED to respond with a `Content-Type` matching to the Wallet's requested `Accept` Header. However, the Credential Issuer MAY ignore the `Accept` Header. In any way, it MUST indicate the type of the returned Credential Issuer Metadata using the HTTP `Content-Type`.
+The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type`. It is RECOMMENDED to respond with a `Content-Type` matching to the Wallet's requested `Accept` Header. However, the Credential Issuer MAY ignore the `Accept` Header.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1280,7 +1280,7 @@ Host: server.example.com
 Accept-Language: fr-ch, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5
 ```
 
-### Signed Metadata
+### Signed Metadata {#credential-issuer-signed-metadata}
 
 The signed metadata MUST be secured using a JSON Web Signature (JWS) [@!RFC7515] and contain the following elements:
 
@@ -2791,6 +2791,28 @@ in the manner described in [@RFC6838].
 * Interoperability considerations: n/a
 * Published specification: (#keyattestation-jwt) of this specification
 * Applications that use this media type: Applications that use the key attestation format defined in this specification
+* Additional information:
+  - Magic number(s): n/a
+  - File extension(s): n/a
+  - Macintosh file type code(s): n/a
+* Person & email address to contact for further information: Torsten Lodderstedt, torsten@lodderstedt.net
+* Intended usage: COMMON
+* Restrictions on usage: none
+* Author: Torsten Lodderstedt, torsten@lodderstedt.net
+* Change controller: OpenID Foundation Digital Credentials Protocols Working Group - openid-specs-digital-credentials-protocols@lists.openid.net
+* Provisional registration? No
+
+### application/openidvci-issuer-metadata+jwt
+
+* Type name: `application`
+* Subtype name: `openidvci-issuer-metadata+jwt`
+* Required parameters: n/a
+* Optional parameters: n/a
+* Encoding considerations: Uses JWS Compact Serialization, as specified in [@!RFC7515].
+* Security considerations: See the Security Considerations in [@!RFC7519].
+* Interoperability considerations: n/a
+* Published specification: (#credential-issuer-signed-metadata) of this specification
+* Applications that use this media type: Applications that use signed metadata format defined in this specification
 * Additional information:
   - Magic number(s): n/a
   - File extension(s): n/a

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1294,7 +1294,7 @@ The signed metadata MUST be secured using a JSON Web Signature (JWS) [@!RFC7515]
   * `iat`: REQUIRED. Integer for the time at which the Credential Issuer Metadata was issued using the syntax defined in [@!RFC7519].
   * `exp`: OPTIONAL. Integer for the time at which the Credential Issuer Metadata is expiring, using the syntax defined in [@!RFC7519].
 
-The Wallet MUST establish trust in the signer of the metadata. Otherwise, the Wallet MUST reject the signed metadata. When validating the signature, the Wallet obtains the keys to validate the signature before processing the metadata, e.g. using JOSE header parameters like `x5c`, `kid` or `trust_chain` to convey the public key. The concrete mechanisms how to do that are out of scope of this specification.
+When requesting signed metadata, the Wallet MUST establish trust in the signer of the metadata. Otherwise, the Wallet MUST reject the signed metadata. When validating the signature, the Wallet obtains the keys to validate the signature before processing the metadata, e.g. using JOSE header parameters like `x5c`, `kid` or `trust_chain` to convey the public key. The concrete mechanisms how to do that are out of scope of this specification.
 
 ### Credential Issuer Metadata Parameters {#credential-issuer-parameters}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1410,7 +1410,7 @@ For example, the metadata for the Credential Issuer Identifier `https://issuer.e
 
 Communication with the Credential Issuer Metadata Endpoint MUST utilize TLS.
 
-To fetch the Credential Issuer Metadata, the Wallet MUST send an HTTP request using the GET method and the path formed following the steps above. The Wallet is RECOMMENDED to send an `Accept` Header in the HTTP GET request to indicate whether it supports signed metadata.
+To fetch the Credential Issuer Metadata, the Wallet MUST send an HTTP request using the GET method and the path formed following the steps above. The Wallet is RECOMMENDED to send an `Accept` Header in the HTTP GET request to indicate the Content Type(s) it supports, and by doing so, signaling whether it supports signed metadata.
 
 The Credential Issuer MUST respond with HTTP Status Code 200 and return the Credential Issuer Metadata containing the [parameters defined in this specification](#credential-issuer-parameters) as either:
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1263,7 +1263,7 @@ The Credential Issuer MUST respond with HTTP Status Code 200 and return the Cred
 * an unsigned JSON document using the media type `application/json`, or
 * a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`.
 
-The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` header. However, the Credential Issuer MAY ignore the `Accept` header, e.g. if it doesn't support signed metadata or has another preference.
+The Credential Issuer MUST support returning metadata in an unsigned form 'application/json' and MAY support returning it in a signed form 'application/jwt'. In all cases the Credential Issuer MUST indicate the media type of the returned Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` header when the requested content type is supported.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 
@@ -1294,7 +1294,7 @@ The signed metadata MUST be secured using a JSON Web Signature (JWS) [@!RFC7515]
   * `iat`: REQUIRED. Integer for the time at which the Credential Issuer Metadata was issued using the syntax defined in [@!RFC7519].
   * `exp`: OPTIONAL. Integer for the time at which the Credential Issuer Metadata is expiring, using the syntax defined in [@!RFC7519].
 
-The Wallet SHOULD establish trust in the signer of the metadata, and obtain the keys to validate the signature before processing the metadata, e.g. using JOSE header parameters like `x5c`, `kid` or `trust_chain` to convey the public key. The concrete mechanisms how to do that are out of scope of this specification. 
+The Wallet MUST establish trust in the signer of the metadata. Otherwise, the Wallet MUST reject the signed metadata. When validating the signature, the Wallet obtains the keys to validate the signature before processing the metadata, e.g. using JOSE header parameters like `x5c`, `kid` or `trust_chain` to convey the public key. The concrete mechanisms how to do that are out of scope of this specification.
 
 ### Credential Issuer Metadata Parameters {#credential-issuer-parameters}
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1440,7 +1440,7 @@ The signed metadata MUST be secured using a JSON Web Signature (JWS) [@!RFC7515]
 
 * in the JOSE header,
   * `alg`: REQUIRED. A digital signature algorithm identifier such as per IANA "JSON Web Signature and Encryption Algorithms" registry [@IANA.JOSE]. It MUST NOT be `none` or an identifier for a symmetric algorithm (MAC).
-  * `typ`: REQUIRED. MUST be `key-attestation+jwt`, which explicitly types the key proof JWT as recommended in Section 3.11 of [@!RFC8725].
+  * `typ`: REQUIRED. MUST be `openidvci-issuer-metadata+jwt`, which explicitly types the key proof JWT as recommended in Section 3.11 of [@!RFC8725].
 
 * in the JWT body,
   * `iss`: OPTIONAL. String denoting the party attesting to the claims in the signed metadata

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1263,7 +1263,7 @@ The Credential Issuer MUST respond with HTTP Status Code 200 and return the Cred
 * an unsigned JSON document using the media type `application/json`, or
 * a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`.
 
-The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` header. However, the Credential Issuer MAY ignore the `Accept` header, e.g. if he doesn't support signed metadata or has another preference.
+The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` header. However, the Credential Issuer MAY ignore the `Accept` header, e.g. if it doesn't support signed metadata or has another preference.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1395,7 +1395,7 @@ Credential Issuers publishing metadata MUST make a JSON document available at th
 
 Communication with the Credential Issuer Metadata Endpoint MUST utilize TLS.
 
-To fetch the Credential Issuer Metadata, the Wallet MUST send an HTTP request using the GET method and the path formed following the steps above. The Wallet is RECOMMENDED to send an `Accept-Content` Header in the HTTP GET request to indicate whether it supports signed metadata.
+To fetch the Credential Issuer Metadata, the Wallet MUST send an HTTP request using the GET method and the path formed following the steps above. The Wallet is RECOMMENDED to send an `Accept` Header in the HTTP GET request to indicate whether it supports signed metadata.
 
 The Credential Issuer MUST respond with HTTP Status Code 200 and return the Credential Issuer Metadata containing the [parameters defined in this specification](#credential-issuer-parameters) as either:
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1421,7 +1421,7 @@ Accept-Language: fr-ch, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5
 
 ### Signed Metadata
 
-The signed metadata MUST be secured using JSON Web Signature (JWS) [@!RFC7515] and MUST contain the following elements:
+The signed metadata MUST be secured using a JSON Web Signature (JWS) [@!RFC7515] and contain the following elements:
 
 * in the JOSE header,
   * `alg`: REQUIRED. A digital signature algorithm identifier such as per IANA "JSON Web Signature and Encryption Algorithms" registry [@IANA.JOSE]. It MUST NOT be `none` or an identifier for a symmetric algorithm (MAC).

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1258,12 +1258,12 @@ Communication with the Credential Issuer Metadata Endpoint MUST utilize TLS.
 
 To fetch the Credential Issuer Metadata, the Wallet MUST send an HTTP request using the GET method and the path formed following the steps above. The Wallet is RECOMMENDED to send an `Accept` Header in the HTTP GET request to indicate the Content Type(s) it supports, and by doing so, signaling whether it supports signed metadata.
 
-The Credential Issuer MUST respond with HTTP Status Code 200 and return the Credential Issuer Metadata containing the [parameters defined in this specification](#credential-issuer-parameters) as either:
+The Credential Issuer MUST respond with HTTP Status Code 200 and return the Credential Issuer Metadata containing the parameters defined in (#credential-issuer-parameters) as either
 
-* an unsigned JSON document using the media type `application/json`
-* a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`
+* an unsigned JSON document using the media type `application/json`, or
+* a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`.
 
-The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` Header. However, the Credential Issuer MAY ignore the `Accept` Header.
+The Credential Issuer MUST indicate the media type of the returned Credential Issuer Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` header. However, the Credential Issuer MAY ignore the `Accept` header, e.g. if he doesn't support signed metadata or has another preference.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1256,7 +1256,7 @@ For example, the metadata for the Credential Issuer Identifier `https://issuer.e
 
 Communication with the Credential Issuer Metadata Endpoint MUST utilize TLS.
 
-To fetch the Credential Issuer Metadata, the Wallet MUST send an HTTP request using the GET method and the path formed following the steps above. The Wallet is RECOMMENDED to send an `Accept` Header in the HTTP GET request to indicate the Content Type(s) it supports, and by doing so, signaling whether it supports signed metadata.
+To fetch the Credential Issuer Metadata, the Wallet MUST send an HTTP request using the GET method and the path formed following the steps above. The Wallet is RECOMMENDED to send an `Accept` header in the HTTP GET request to indicate the Content Type(s) it supports, and by doing so, signaling whether it supports signed metadata.
 
 The Credential Issuer MUST respond with HTTP Status Code 200 and return the Credential Issuer Metadata containing the parameters defined in (#credential-issuer-parameters) as either
 
@@ -1265,7 +1265,7 @@ The Credential Issuer MUST respond with HTTP Status Code 200 and return the Cred
 
 The Credential Issuer MUST support returning metadata in an unsigned form 'application/json' and MAY support returning it in a signed form 'application/jwt'. In all cases the Credential Issuer MUST indicate the media type of the returned Metadata using the HTTP `Content-Type` header. It is RECOMMENDED for Credential Issuers to respond with a `Content-Type` matching to the Wallet's requested `Accept` header when the requested content type is supported.
 
-The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
+The Wallet is RECOMMENDED to send an `Accept-Language` header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 
 * send a subset the metadata containing internationalized display data for one or all of the requested languages and indicate returned languages using the HTTP `Content-Language` Header, or
 * ignore the `Accept-Language` Header and send all supported languages or any chosen subset.
@@ -1290,7 +1290,7 @@ The signed metadata MUST be secured using a JSON Web Signature (JWS) [@!RFC7515]
 
 * in the JWT body,
   * `iss`: OPTIONAL. String denoting the party attesting to the claims in the signed metadata
-  * `sub`: REQUIRED. String matching the Credential Issuer identifier
+  * `sub`: REQUIRED. String matching the Credential Issuer Identifier
   * `iat`: REQUIRED. Integer for the time at which the Credential Issuer Metadata was issued using the syntax defined in [@!RFC7519].
   * `exp`: OPTIONAL. Integer for the time at which the Credential Issuer Metadata is expiring, using the syntax defined in [@!RFC7519].
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1402,7 +1402,7 @@ The Credential Issuer MUST respond with HTTP Status Code 200 and return the Cred
 * an unsigned JSON document using the media type `application/json`
 * a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`
 
-The Credential Issuer MAY ignore the `Accept-Content` Header. It MUST indicate the type of the returned Credential Issuer Metadata using the HTTP `Content-Type`.
+The Credential Issuer MAY ignore the `Accept` Header. It MUST indicate the type of the returned Credential Issuer Metadata using the HTTP `Content-Type`.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1417,7 +1417,7 @@ The Credential Issuer MUST respond with HTTP Status Code 200 and return the Cred
 * an unsigned JSON document using the media type `application/json`
 * a signed JSON Web Token (JWT) containing the Credential Issuer Metadata in its payload using the media type `application/jwt`
 
-The Credential Issuer MAY ignore the `Accept` Header. It MUST indicate the type of the returned Credential Issuer Metadata using the HTTP `Content-Type`.
+The Credential Issuer is RECOMMENDED to respond with a `Content-Type` matching to the Wallet's requested `Accept` Header. However, the Credential Issuer MAY ignore the `Accept` Header. In any way, it MUST indicate the type of the returned Credential Issuer Metadata using the HTTP `Content-Type`.
 
 The Wallet is RECOMMENDED to send an `Accept-Language` Header in the HTTP GET request to indicate the language(s) preferred for display. It is up to the Credential Issuer whether to:
 


### PR DESCRIPTION
Closes #202 

- [ ] discuss whether to use JWS instead of JWT for multiple trust frameworks