### PR TITLE
Attempt to clarify intro text about key attestations

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -922,7 +922,7 @@ There are two ways to convey key attestations (as defined in (#keyattestation)) 
 - The Wallet uses the `jwt` proof type in the Credential Request to create a proof of possession for one of the attested keys and adds the key attestation in the JOSE header.
 - The Wallet uses the `attestation` proof type in the Credential Request to provide a key attestation without a proof of possession of any of the keys.
 
-Depending on the Wallet's implementation, the `attestation` may avoid unnecessary End-User interaction during Credential issuance, as the key to which the Credential will be bound does not necessarily need to perform signature operations.
+Depending on the Wallet's implementation, the `attestation` may avoid unnecessary End-User interaction during Credential issuance, as the key(s) to which the Credential(s) will be bound does not necessarily need to perform signature operations, and one key attestation can be used to attest multiple keys.
 
 Additional proof types MAY be defined and used.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -919,10 +919,10 @@ This specification defines the following proof types:
 
 There are two ways to convey key attestations (as defined in (#keyattestation)) of the cryptographic key material during Credential issuance:
 
-- The Wallet uses the `jwt` proof type in the Credential Request to create a proof of possession of the key and adds the key attestation in the JOSE header.
-- The Wallet uses the `attestation` proof type in the Credential Request with the key attestation without a proof of possession of the key itself.
+- The Wallet uses the `jwt` proof type in the Credential Request to create a proof of possession for one of the attested keys and adds the key attestation in the JOSE header.
+- The Wallet uses the `attestation` proof type in the Credential Request to provide a key attestation without a proof of possession of any of the keys.
 
-Depending on the Wallet's implementation, the `attestation` may avoid unnecessary End-User interaction during Credential issuance, as the key itself does not necessarily need to perform signature operations.
+Depending on the Wallet's implementation, the `attestation` may avoid unnecessary End-User interaction during Credential issuance, as the key to which the credential will be bound does not necessarily need to perform signature operations.
 
 Additional proof types MAY be defined and used.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -922,7 +922,7 @@ There are two ways to convey key attestations (as defined in (#keyattestation)) 
 - The Wallet uses the `jwt` proof type in the Credential Request to create a proof of possession for one of the attested keys and adds the key attestation in the JOSE header.
 - The Wallet uses the `attestation` proof type in the Credential Request to provide a key attestation without a proof of possession of any of the keys.
 
-Depending on the Wallet's implementation, the `attestation` may avoid unnecessary End-User interaction during Credential issuance, as the key to which the credential will be bound does not necessarily need to perform signature operations.
+Depending on the Wallet's implementation, the `attestation` may avoid unnecessary End-User interaction during Credential issuance, as the key to which the Credential will be bound does not necessarily need to perform signature operations.
 
 Additional proof types MAY be defined and used.
 


### PR DESCRIPTION
The singular "key" was being used in a way that could be confusing given a single key attestation can be used to attest multiple keys.

closes #463