### PR TITLE
Cleanup language around c_nonce

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -814,7 +814,7 @@ See (#identifying_credential) for the summary of the options how requested Crede
 
 The proof type contained in the `proofs` parameter is an extension point that enables the use of different types of proofs for different cryptographic schemes.
 
-The proof(s) in the `proofs` parameter MUST incorporate the Credential Issuer Identifier (audience) and, if the Credential has a Nonce Endpoint, a `c_nonce` value to allow the Credential Issuer to detect freshness. The way that data is incorporated depends on the key proof type. In a JWT, for example, the `c_nonce` value is conveyed in the `nonce` claim, whereas the audience is conveyed in the `aud` claim. In a Linked Data proof, for example, the `c_nonce` is included as the `challenge` element in the key proof object and the Credential Issuer (the intended audience) is included as the `domain` element.
+The proof(s) in the `proofs` parameter MUST incorporate the Credential Issuer Identifier (audience) and, if the Credential Issuer has a Nonce Endpoint, a `c_nonce` value to allow the Credential Issuer to detect freshness. The way that data is incorporated depends on the key proof type. In a JWT, for example, the `c_nonce` value is conveyed in the `nonce` claim, whereas the audience is conveyed in the `aud` claim. In a Linked Data proof, for example, the `c_nonce` is included as the `challenge` element in the key proof object and the Credential Issuer (the intended audience) is included as the `domain` element.
 
 The `proofs` parameter MUST be present if the `proof_types_supported` parameter is present in the `credential_configurations_supported` parameter of the Issuer metadata for the requested Credential.
 


### PR DESCRIPTION
We still had text that assumed the c_nonce was proactively sent to the wallet, rather than (as is now the case) fetched by the wallet.

Also clarify that the nonce is a challenge rather than a nonce (without changing any parameter names!), and that 'unpredictable' does not mean that the same value cannot be used for a short time.

Some of the language is quite similar to the language in DPoP around the DPoP nonces, as there is a lot of similarity - both mechanisms do not (fully) prevent replay but do ensure freshness.

relates to some of the points raised in #461

relates the confusion that prompted #496

adds some clarify around the 'what nonces are' part of #491