### PR TITLE
Add version number (1.0) to document title

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1,5 +1,5 @@
 %%%
-title = "OpenID for Verifiable Credential Issuance - Editor's draft"
+title = "OpenID for Verifiable Credential Issuance 1.0 - Editor's draft"
 abbrev = "openid-4-verifiable-credential-issuance"
 ipr = "none"
 workgroup = "OpenID Digital Credentials Protocols"


### PR DESCRIPTION
OIDF drafts normally contain a version number in the title when a version number is included in the title of final, and because of the high likelyhood of a 1.1 revision we do want extra prominance on the version number.