### PR TITLE
Merge Deferred Credential Endpoint text into Credential Endpoint

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -810,19 +810,13 @@ For Cryptographic Key Binding, the Client has different options to provide Crypt
 
 ## Credential Request {#credential-request}
 
-A Client makes a Credential Request to the Credential Endpoint by sending the following parameters in the entity-body of an HTTP POST request. The Credential Request MAY be encrypted (on top of TLS) using the `credential_request_encryption` parameter in (#credential-issuer-metadata) as specified in (#encrypted-messages).
-
-* `credential_response_encryption`: OPTIONAL. Object containing information for encrypting the Credential Response. If this request element is not present, the corresponding credential response returned is not encrypted.
-    * `jwk`: REQUIRED. Object containing a single public key as a JWK used for encrypting the Credential Response.
-    * `enc`: REQUIRED. JWE [@!RFC7516] `enc` algorithm [@!RFC7518] for encrypting Credential Responses.
-    * `zip`: OPTIONAL. JWE [@!RFC7516] `zip` algorithm [@!RFC7518] for compressing Credential Responses prior to encryption. If absent then compression MUST not be used.
+A Client makes a Credential Request to the Credential Endpoint by sending parameters in the entity-body of an HTTP POST request. The Credential Request MAY be encrypted (on top of TLS) using the `credential_request_encryption` parameter in (#credential-issuer-metadata) as specified in (#encrypted-messages).
 
 In an initial Credential Request the Client includes the following parameters: 
 
 * `credential_identifier`: REQUIRED when an Authorization Details of type `openid_credential` was returned from the Token Response. It MUST NOT be used otherwise. A string that identifies a Credential Dataset that is requested for issuance. When this parameter is used, the `credential_configuration_id` MUST NOT be present.
 * `credential_configuration_id`: REQUIRED if a `credential_identifiers` parameter was not returned from the Token Response as part of the `authorization_details` parameter. It MUST NOT be used otherwise. String that uniquely identifies one of the keys in the name/value pairs stored in the `credential_configurations_supported` Credential Issuer metadata. The corresponding object in the `credential_configurations_supported` map MUST contain one of the value(s) used in the `scope` parameter in the Authorization Request. When this parameter is used, the `credential_identifier` MUST NOT be present.
 * `proofs`: OPTIONAL. Object providing one or more proof of possessions of the cryptographic key material to which the issued Credential instances will be bound to. The `proofs` parameter contains exactly one parameter named as the proof type in (#proof-types), the value set for this parameter is a non-empty array containing parameters as defined by the corresponding proof type.
-
 
 See (#identifying_credential) for the summary of the options how requested Credential(s) are identified throughout the Issuance flow.
 
@@ -852,6 +846,13 @@ Authorization: Bearer czZCaGRSa3F0MzpnWDFmQmF0M2JW
   "transaction_id": "8xLOxBtZp8"
 }
 ```
+
+The following parameters may be any Credential Request:
+
+* `credential_response_encryption`: OPTIONAL. Object containing information for encrypting the Credential Response. If this request element is not present, the corresponding credential response returned is not encrypted.
+    * `jwk`: REQUIRED. Object containing a single public key as a JWK used for encrypting the Credential Response.
+    * `enc`: REQUIRED. JWE [@!RFC7516] `enc` algorithm [@!RFC7518] for encrypting Credential Responses.
+    * `zip`: OPTIONAL. JWE [@!RFC7516] `zip` algorithm [@!RFC7518] for compressing Credential Responses prior to encryption. If absent then compression MUST not be used.
 
 Additional Credential Request parameters MAY be defined and used.
 The Credential Issuer MUST ignore any unrecognized parameters.
@@ -1059,7 +1060,7 @@ Cache-Control: no-store
 
 # Deferred Credential Endpoint {#deferred-credential-issuance}
 
-This endpoint is a specialized Credential Endpoint for handling Deferred Credential Requests. The Deferred Credential Endpoint follows all the requirements in {#credential-endpoint}. Additionally, all Credential Requests MUST contain `transaction_id`. Support for this endpoint is OPTIONAL.
+This endpoint is a specialized Credential Endpoint for handling Deferred Credential Requests. The Deferred Credential Endpoint follows all the requirements in {#credential-endpoint}. All Credential Requests MUST contain `transaction_id`. Support for this endpoint is OPTIONAL.
 
 ## Encrypted Messages {#encrypted-messages}
 Encryption of Request and Response Messages is performed as follows:

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -810,7 +810,7 @@ For Cryptographic Key Binding, the Client has different options to provide Crypt
 
 ## Credential Request {#credential-request}
 
-A Client makes a Credential Request to the Credential Endpoint by sending parameters in the entity-body of an HTTP POST request. The Credential Request MAY be encrypted (on top of TLS) using the `credential_request_encryption` parameter in (#credential-issuer-metadata) as specified in (#encrypted-messages).
+A Client makes a Credential Request to the Credential Endpoint by sending parameters in the entity-body of an HTTP POST request. The Credential Request MAY be encrypted (on top of TLS) using the encryption settings as defined in the `credential_request_encryption` metadata parameter in (#credential-issuer-metadata) as specified in (#encrypted-messages).
 
 In a Credential Request made to the Credential Endpoint the Client includes the following parameters: 
 
@@ -930,7 +930,7 @@ Authorization: Bearer czZCaGRSa3F0MzpnWDFmQmF0M2JW
 }
 ```
 
-All Credential Request(s) include the following parameters:
+All Credential Request(s) MAY include the following parameters:
 
 * `credential_response_encryption`: OPTIONAL. Object containing information for encrypting the Credential Response. If this request element is not present, the corresponding credential response returned is not encrypted.
     * `jwk`: REQUIRED. Object containing a single public key as a JWK used for encrypting the Credential Response.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -847,7 +847,7 @@ Authorization: Bearer czZCaGRSa3F0MzpnWDFmQmF0M2JW
 }
 ```
 
-The following parameters may be any Credential Request:
+All Credential Request(s) include the following parameters:
 
 * `credential_response_encryption`: OPTIONAL. Object containing information for encrypting the Credential Response. If this request element is not present, the corresponding credential response returned is not encrypted.
     * `jwk`: REQUIRED. Object containing a single public key as a JWK used for encrypting the Credential Response.


### PR DESCRIPTION
Resolves #523

The goal of this is to change the semantics of how requests to and from Credential Endpoint and Deferred Credential Endpoint work. 

Today: Credential Endpoint takes Credential Requests and returns Credential Responses, while Deferred Credential Endpoint takes Deferred Credential Requests (which references some parameters from Credential Request) and return Deferred Credential Responses (which references some parameters from Credential Responses). 

After this change: Credential Endpoint and Deferred Credential Endpoint take Credential Requests and return Credential Responses. 
  - Credential Requests to the Credential Endpoint can additionally include parameters related to proofs + identifying the Credential configuration
  - Credential Requests to the Deferred Credential Endpoint can additionally include `transaction_id`. 
  - Credential Responses are the same from both. 

This results in one normative change: 
- Credential Responses from Deferred Credential Endpoint that continue to defer MUST include `transaction_id`, unchanged from the request. This does not result in a behavioral change, and aligns what is returned from Credential Endpoint and Deferred Credential Endpoint.

The intended benefits of this semantic change are as follows: 
  - The endpoints become more consistent with one another, reducing edge cases when comparing deferred vs non-deferred flows. 
  - Wallets can process responses uniformly, regardless of whether they are returned initially or in subsequent requests
  - Future extensions more easily apply to both (for both responses and requests). 

