### PR TITLE
Fix url for VC_DATA to reference the 1.1 version

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -2015,7 +2015,7 @@ regulation), the Credential Issuer should properly authenticate the Wallet and e
         </front>
 </reference>
 
-<reference anchor="VC_DATA" target="https://www.w3.org/TR/vc-data-model">
+<reference anchor="VC_DATA" target="https://www.w3.org/TR/2022/REC-vc-data-model-20220303">
   <front>
     <title>Verifiable Credentials Data Model 1.1</title>
     <author fullname="Manu Sporny">


### PR DESCRIPTION
Currently `VC_DATA` references `https://www.w3.org/TR/vc-data-model` which is now on version `2.0`, as the intention is to reference the `1.1` version, the url should be updated to `https://www.w3.org/TR/2022/REC-vc-data-model-20220303`.