### PR TITLE
add credential format specific sections for IAR endpoint binding in VPs

### DIFF
--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -2692,7 +2692,7 @@ OpenID4VCIIAEHandover = [
 OpenID4VCIIAEHandoverInfoHash = bstr
 
 ; Contains the bytes of OpenID4VCIIAEHandoverInfo encoded as CBOR
-OpenID4VCIIAEHandoverBytes = bstr .cbor OpenID4VCIIAEHandoverInfo
+OpenID4VCIIAEHandoverInfoBytes = bstr .cbor OpenID4VCIIAEHandoverInfo
 
 OpenID4VCIIAEHandoverInfo = [
   iae,


### PR DESCRIPTION
This PR fixes #590 and #620 by adding credential format specific sections for IAR endpoint binding in VPs.

- [x] Is it clear enough that Credential Formats correspond to the requested Credential in the IAR, and not to the requested Credential in the VCI request?
- [x] Examples for IAR `SessionTranscript` need to be regenerated
- [x] Fix 620
- [ ] I did not update the audience in the VP, see comment below https://github.com/openid/OpenID4VCI/pull/602#issuecomment-3184017712, but proposal here https://github.com/openid/OpenID4VCI/pull/629