### PR TITLE
allow new `auth_session` values in interactive authorization responses

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -767,7 +767,7 @@ In this case, the following keys MUST be present in the response as well:
 * `type`: REQUIRED. String indicating which type of interaction is required, as defined below. The Authorization Server MUST NOT set this to a value that was not included in the `interaction_types_supported` parameter sent by the Wallet.
 * `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value.
 
-The Wallet MUST include the `auth_session` in all follow-up requests to the Interactive Authorization Endpoint.
+The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
 If, as a response to such a follow-up request, the Wallet receives an `auth_session` value that differs from the one sent in the request, it MUST use the newly received `auth_session` for all subsequent requests, until a different `auth_session` value is received.
 
 If a wallet receives a `type` value that it does not recognize, it MUST abort the issuance process.

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -768,7 +768,9 @@ In this case, the following keys MUST be present in the response as well:
 * `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value.
 
 The Wallet MUST include the `auth_session` in all follow-up requests to the Interactive Authorization Endpoint.
-If, as a response to such a follow-up request, the Wallet receives an `auth_session` value that differs from the one sent in the request, it MUST abort the issuance process.
+If, as a response to such a follow-up request, the Wallet receives an `auth_session` value that differs from the one sent in the request, it MUST use the newly received `auth_session` for all subsequent requests, until a different `auth_session` value is received.
+
+the abort the issuance process.
 
 If a wallet receives a `type` value that it does not recognize, it MUST abort the issuance process.
 
@@ -3346,6 +3348,7 @@ The technology described in this specification was made available from contribut
    * add example for signed credential issuer metadata
    * add another more complex example for credential issuer metadata
    * fix indentation of nested credential logo object
+   * allow new `auth_session` values in interactive authorization responses
 
    -16
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -768,7 +768,6 @@ In this case, the following keys MUST be present in the response as well:
 * `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value.
 
 The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
-If, as a response to such a follow-up request, the Wallet receives an `auth_session` value that differs from the one sent in the request, it MUST use the newly received `auth_session` for all subsequent requests, until a different `auth_session` value is received.
 
 If a wallet receives a `type` value that it does not recognize, it MUST abort the issuance process.
 

--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -770,8 +770,6 @@ In this case, the following keys MUST be present in the response as well:
 The Wallet MUST include the `auth_session` in all follow-up requests to the Interactive Authorization Endpoint.
 If, as a response to such a follow-up request, the Wallet receives an `auth_session` value that differs from the one sent in the request, it MUST use the newly received `auth_session` for all subsequent requests, until a different `auth_session` value is received.
 
-the abort the issuance process.
-
 If a wallet receives a `type` value that it does not recognize, it MUST abort the issuance process.
 
 Additional keys are defined based on the type of interaction, as shown next.


### PR DESCRIPTION
Fixes #609 