### PR TITLE
Fix examples/credential_metadata_ldp_vc.json

### DIFF
--- a/examples/credential_metadata_ldp_vc.json
+++ b/examples/credential_metadata_ldp_vc.json
@@ -8,7 +8,7 @@
       "credential_signing_alg_values_supported": [
         "Ed25519Signature2018"
       ],
-      "credentials_definition": {
+      "credential_definition": {
         "@context": [
           "https://www.w3.org/2018/credentials/v1",
           "https://www.w3.org/2018/credentials/examples/v1"
@@ -16,10 +16,6 @@
         "type": [
           "VerifiableCredential",
           "UniversityDegreeCredential"
-        ],
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://www.w3.org/2018/credentials/examples/v1"
         ]
       },
       "credential_metadata": {


### PR DESCRIPTION
This PR makes [example](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html#name-credential-issuer-metadata-3) of an object containing the `credential_configurations_supported` parameter for Credential Format `ldp_vc` compatible with normative prose.

Changes:
- rename "$.credential_configurations_supported.credentials_definition" to "$.credential_configurations_supported.credential_definition":
  - plural to singular form;
- remove "$.credential_configurations_supported.credential_definition.@context" duplicate.