### PR TITLE
Move Encrypted Messages to the top level

### DIFF
--- a/openid-4-verifiable-credential-issuance-1_0.md
+++ b/openid-4-verifiable-credential-issuance-1_0.md
@@ -1168,8 +1168,8 @@ Cache-Control: no-store
 
 In the event the Credential Issuer can no longer issue the credential(s), the `credential_request_denied` error code as defined in (#credential-request-errors) should be used in response to a request. A wallet upon receiving this error SHOULD stop making requests to the deferred credential endpoint for the given `transaction_id`. 
 
-# Encrypted Messages {#encrypted-messages}
-Encryption of Request and Response Messages is performed as follows:
+# Encrypted Credential Requests and Responses {#encrypted-messages}
+Encryption of requests and responses for the Credential and Deferred Credential Endpoints is performed as follows:
 
 The contents of the message MUST be encoded as a JWT as described in [@!RFC7519]. The media type MUST be set to `application/jwt`.
 


### PR DESCRIPTION
Resolve #638

It wasn't clear from the comment as to which way the working group wished to resolve this. Moved it to the top level in this PR, mostly so that it could also be referenced by other sections (such as IAR) in the future, but happy to move it instead if people prefer.