### PR TITLE
Update draft number for 1.0, add errata to title, add history section

### DIFF
--- a/1.0/openid-4-verifiable-credential-issuance-1_0.md
+++ b/1.0/openid-4-verifiable-credential-issuance-1_0.md
@@ -7,7 +7,7 @@ keyword = ["security", "openid", "ssi"]
 
 [seriesInfo]
 name = "Internet-Draft"
-value = "openid-4-verifiable-credential-issuance-1_0-18"
+value = "openid-4-verifiable-credential-issuance-1_0-19"
 status = "standard"
 
 [[author]]
@@ -3024,6 +3024,10 @@ The technology described in this specification was made available from contribut
 
    [[ To be removed from the final specification ]]
 
-   -18
+-19
 
-   * TBC
+   * TBD 
+   
+-final
+   
+   * https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-final.html


### PR DESCRIPTION
Administrative changes to put the 1.0 spec into a state where we can start adding any potential errata updates.

I don't think we're definitely at the point where we know we will want to publish a 1.0 errata, but we at least need to "Editor's draft" back to the version published on GitHub pages, and so it seemed sensible to make the other changes too.