### PR TITLE
Fixes to Notification Request examples

### DIFF
--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -1632,7 +1632,7 @@ Authorization: Bearer czZCaGRSa3F0MzpnWDFmQmF0M2JW
 }
 ```
 
-Below is a non-normative example of a Notification Request when a Credential was deleted by the End-User:
+Below is a non-normative example of a Notification Request when a Credential was rejected by the End-User:
 
 ```
 POST /notification HTTP/1.1
@@ -1643,7 +1643,7 @@ Authorization: Bearer czZCaGRSa3F0MzpnWDFmQmF0M2JW
 {
   "notification_id": "3fwe98js",
   "event": "credential_deleted",
-  "event_description": "User deleted the issued Credential."
+  "event_description": "User rejected the issued Credential."
 }
 ```
 


### PR DESCRIPTION
This pull request proposes a fix to an inconsistency in the second Notification Request example by adding a proper `credential_deleted` example and adding a new description to the `credential_failure`example. The pull request also proposes changing “was deleted by the End-User” with “was rejected by the End-User”, because the verb “deleted” can be understood to mean a deletion that the user does much later after accepting the issuance of the credential (which might not be supported, see https://github.com/openid/OpenID4VCI/issues/673), while “rejected” is much more tied to the issuance of the credential.

This pull request relates to issue https://github.com/openid/OpenID4VCI/issues/674. The inconsistency in the second Notification Request is explained there.