### PR TITLE
add credential format profile for vcdm 2 with jose

### DIFF
--- a/1.1/examples/authorization_details_vc_jwt.json
+++ b/1.1/examples/authorization_details_vc_jwt.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "openid_credential",
+    "credential_configuration_id": "UniversityDegreeCredential",
+    "claims": [
+      {"path": ["credentialSubject", "given_name"]},
+      {"path": ["credentialSubject", "family_name"]},
+      {"path": ["credentialSubject", "degree"]}
+    ]
+  }
+]

--- a/1.1/examples/authorization_details_vc_sd_jwt.json
+++ b/1.1/examples/authorization_details_vc_sd_jwt.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "openid_credential",
+    "credential_configuration_id": "UniversityDegreeCredential",
+    "claims": [
+      {"path": ["credentialSubject", "given_name"]},
+      {"path": ["credentialSubject", "family_name"]},
+      {"path": ["credentialSubject", "degree"]}
+    ]
+  }
+]

--- a/1.1/examples/credential_metadata_vc_jwt.json
+++ b/1.1/examples/credential_metadata_vc_jwt.json
@@ -1,0 +1,72 @@
+{
+  "credential_configurations_supported": {
+    "UniversityDegreeCredential": {
+      "format": "vc+jwt",
+      "scope": "UniversityDegree",
+      "cryptographic_binding_methods_supported": [
+        "did:example",
+        "did:key"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "credential_definition": {
+        "type": [
+          "VerifiableCredential",
+          "UniversityDegreeCredential"
+        ]
+      },
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "claims": [
+          {
+            "path": ["credentialSubject", "given_name"],
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": ["credentialSubject", "family_name"],
+            "display": [
+              {
+                "name": "Surname",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {"path": ["credentialSubject", "degree"]},
+          {
+            "path": ["credentialSubject", "gpa"],
+            "mandatory": true,
+            "display": [
+              {
+                "name": "GPA"
+              }
+            ]
+          }
+        ],
+        "display": [
+          {
+            "name": "University Credential",
+            "locale": "en-US",
+            "logo": {
+              "uri": "https://university.example.edu/public/logo.png",
+              "alt_text": "a square logo of a university"
+            },
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/1.1/examples/credential_metadata_vc_sd_jwt.json
+++ b/1.1/examples/credential_metadata_vc_sd_jwt.json
@@ -1,0 +1,72 @@
+{
+  "credential_configurations_supported": {
+    "UniversityDegreeCredential": {
+      "format": "vc+sd-jwt",
+      "scope": "UniversityDegree",
+      "cryptographic_binding_methods_supported": [
+        "did:example",
+        "did:key"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "credential_definition": {
+        "type": [
+          "VerifiableCredential",
+          "UniversityDegreeCredential"
+        ]
+      },
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "claims": [
+          {
+            "path": ["credentialSubject", "given_name"],
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": ["credentialSubject", "family_name"],
+            "display": [
+              {
+                "name": "Surname",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {"path": ["credentialSubject", "degree"]},
+          {
+            "path": ["credentialSubject", "gpa"],
+            "mandatory": true,
+            "display": [
+              {
+                "name": "GPA"
+              }
+            ]
+          }
+        ],
+        "display": [
+          {
+            "name": "University Credential",
+            "locale": "en-US",
+            "logo": {
+              "uri": "https://university.example.edu/public/logo.png",
+              "alt_text": "a square logo of a university"
+            },
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/1.1/examples/credential_response_vc_jwt.txt
+++ b/1.1/examples/credential_response_vc_jwt.txt
@@ -1,0 +1,62 @@
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+Cache-Control: no-store
+
+{
+  "credentials": [
+    {
+      "credential": "eyJ0eXAiOiJ2Yytqd3QiLCJhbGciOiJFUzI1NiIsImtpZCI6Im
+      RpZDpqd2s6ZXlKcmRIa2lPaUpGUXlJc0ltTnlkaUk2SWxBdE1qVTJJaXdpZUN
+      JNklucFJUMjkzU1VNeFoxZEtkR1JrWkVJMVIwRjBOR3hoZFRaTWREaEphSGsz
+      TnpGcFFXWmhiUzB4Y0dNaUxDSjVJam9pWTJwRVh6ZHZNMmRrVVRGMloybFJlV
+      E5mYzAxSGN6ZFhjbmREVFZVNVJsRlphVzFCTTBoNGJrMXNkeUo5IzAifQ.eyJ
+      AY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHM
+      vdjIiLCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL29iL3YzcDA
+      wL2NvbnRleHQuanNvbiJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWF
+      sIiwiVmVyaWZpYWJsZUNyZWRlbnRpYWxFeHRlbnNpb24iLCJPcGVuQmFkZ2V
+      DcmVkZW50aWFsIl0sImlzc3VlciI6eyJpZCI6ImRpZDpqd2s6ZXlKcmRIa2l
+      PaUpGUXlJc0ltTnlkaUk2SWxBdE1qVTJJaXdpZUNJNklucFJUMjkzU1VNeF
+      oxZEtkR1JrWkVJMVIwRjBOR3hoZFRaTWREaEphSGszTnpGcFFXWmhiUzB4Y
+      0dNaUxDSjVJam9pWTJwRVh6ZHZNMmRrVVRGMloybFJlVE5mYzAxSGN6ZFh
+      Y25kRFRWVTVSbEZaYVcxQk0waDRiazFzZHlKOSIsIm5hbWUiOiJKb2JzIGZ
+      vciBvdGhlIEZ1dHVyZSAoSkZGKSIsImljb25VcmwiOiJodHRwczovL3czYy1
+      jY2cuZ2l0aHViLmlvL3ZjLWVkL3BsdWdmZXN0LTEtMjAyMi9pbWFnZXMvSkZ
+      GX0xvZ29Mb2NrdXAucG5nIiwiaW1hZ2UiOiJodHRwczovL3czYy1jY2cuZ2l
+      0aHViLmlvL3ZjLWVkL3BsdWdmZXN0LTEtMjAyMi9pbWFnZXMvSkZGX0xvZ29
+      Mb2NrdXAucG5nIn0sIm5hbWUiOiJKRkYgeCB2Yy1lZHUgUGx1Z0Zlc3QgMiI
+      sImRlc2NyaXB0aW9uIjoiTUFUVEoncyBzdWJtaXNzaW9uIGZvciBKRkYgUGx
+      1Z2Zlc3QgMiIsImNyZWRlbnRpYWxCcmFuZGluZyI6eyJiYWNrZ3JvdW5kQ29
+      sb3IiOiIjNDY0YzQ5In0sInZhbGlkRnJvbSI6IjIwMjMtMDEtMjVUMTY6NTg
+      6MDYuMjkyWiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmtleTp
+      6Nk1rcWdrTHJSeUxnNmJxazI3ZGp3YmJhUVdnYVNZZ0ZWQ0txOVlLeFpiTmt
+      wVnYiLCJ0eXBlIjpbIkFjaGlldmVtZW50U3ViamVjdCJdLCJhY2hpZXZlbWV
+      udCI6eyJpZCI6InVybjp1dWlkOmJkNmQ5MzE2LWY3YWUtNDA3My1hMWU1LTJ
+      mN2Y1YmQyMjkyMiIsIm5hbWUiOiJKRkYgeCB2Yy1lZHUgUGx1Z0Zlc3QgMiB
+      JbnRlcm9wZXJhYmlsaXR5IiwidHlwZSI6WyJBY2hpZXZlbWVudCJdLCJpbWF
+      nZSI6eyJpZCI6Imh0dHBzOi8vdzNjLWNjZy5naXRodWIuaW8vdmMtZWQvcGx
+      1Z2Zlc3QtMi0yMDIyL2ltYWdlcy9KRkYtVkMtRURVLVBMVUdGRVNUMi1iYWR
+      nZS1pbWFnZS5wbmciLCJ0eXBlIjoiSW1hZ2UifSwiY3JpdGVyaWEiOnsidHl
+      wZSI6IkNyaXRlcmlhIiwibmFycmF0aXZlIjoiU29sdXRpb25zIHByb3ZpZGV
+      ycyBlYXJuZWQgdGhpcyBiYWRnZSBieSBkZW1vbnN0cmF0aW5nIGludGVyb3B
+      lcmFiaWxpdHkgYmV0d2VlbiBtdWx0aXBsZSBwcm92aWRlcnMgYmFzZWQgb24
+      gdGhlIE9CdjMgY2FuZGlkYXRlIGZpbmFsIHN0YW5kYXJkLCB3aXRoIHNvbWU
+      gYWRkaXRpb25hbCByZXF1aXJlZCBmaWVsZHMuIENyZWRlbnRpYWwgaXNzdWV
+      ycyBlYXJuaW5nIHRoaXMgYmFkZ2Ugc3VjY2Vzc2Z1bGx5IGlzc3VlZCBhIGN
+      yZWRlbnRpYWwgaW50byBhdCBsZWFzdCB0d28gd2FsbGV0cy4gIFdhbGxldCB
+      pbXBsZW1lbnRlcnMgZWFybmluZyB0aGlzIGJhZGdlIHN1Y2Nlc3NmdWxseSB
+      kaXNwbGF5ZWQgY3JlZGVudGlhbHMgaXNzdWVkIGJ5IGF0IGxlYXN0IHR3byB
+      kaWZmZXJlbnQgY3JlZGVudGlhbCBpc3N1ZXJzLiJ9LCJkZXNjcmlwdGlvbiI
+      6IlRoaXMgY3JlZGVudGlhbCBzb2x1dGlvbiBzdXBwb3J0cyB0aGUgdXNlIG9
+      mIE9CdjMgYW5kIHczYyBWZXJpZmlhYmxlIENyZWRlbnRpYWxzIGFuZCBpcyB
+      pbnRlcm9wZXJhYmxlIHdpdGggYXQgbGVhc3QgdHdvIG90aGVyIHNvbHV0aW9
+      ucy4gIFRoaXMgd2FzIGRlbW9uc3RyYXRlZCBzdWNjZXNzZnVsbHkgZHVyaW5
+      nIEpGRiB4IHZjLWVkdSBQbHVnRmVzdCAyLiJ9fX0sImNuZiI6eyJraWQiOiJ
+      kaWQ6a2V5Ono2TWtxZ2tMclJ5TGc2YnFrMjdkandiYmFRV2dhU1lnRlZDS3E
+      5WUt4WmJOa3BWdiN6Nk1rcWdrTHJSeUxnNmJxazI3ZGp3YmJhUVdnYVNZZ0Z
+      WQ0txOVlLeFpiTmtwVnYifSwiaWF0IjoxNjk4MTUxNTMyfQ.nGTrQ3gpIKt
+      NJaOUusMYV2ITzN5FMdgu2XSKNu1t-Bxc2uXbnUbP4fkULmGddakfODCA2C
+      uzz2PkL2QqgwOdyA"
+    }
+  ]
+}

--- a/1.1/examples/credential_response_vc_sd_jwt.txt
+++ b/1.1/examples/credential_response_vc_sd_jwt.txt
@@ -1,0 +1,62 @@
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+Cache-Control: no-store
+
+{
+  "credentials": [
+    {
+      "credential": "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsImtp
+      ZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpGUXlJc0ltTnlkaUk2SWxBdE1qVTJJ
+      aXdpZUNJNklucFJUMjkzU1VNeFoxZEtkR1JrWkVJMVIwRjBOR3hoZFRaTWRE
+      aEphSGszTnpGcFFXWmhiUzB4Y0dNaUxDSjVJam9pWTJwRVh6ZHZNMmRrVVRG
+      MloybFJlVE5mYzAxSGN6ZFhjbmREVFZVNVJsRlphVzFCTTBoNGJrMXNkeUo5
+      IzAifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZ
+      GVudGlhbHMvdjIiLCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2
+      9iL3YzcDAvY29udGV4dC5qc29uIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWR
+      lbnRpYWwiLCJWZXJpZmlhYmxlQ3JlZGVudGlhbEV4dGVuc2lvbiIsIk9wZW5C
+      YWRnZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjp7ImlkIjoiZGlkOmp3azpleUpyZ
+      EhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2llQ0k2SW5wUlQyOTNTVU
+      14WjFkS2RHUmtaRUkxUjBGME5HeGhkVFpNZERoSmFIazNOekZwUVdaaGJTMHh
+      jR01pTENKNUlqb2lZMnBFWHpkdk0yZGtVVEYyWjJsUmVUTmZjMDFIY3pkWGNu
+      ZERUVlU1UmxGWmFXMUJNMGg0Ymsxc2R5SjkiLCJuYW1lIjoiSm9icyBmb3IgdG
+      hlIEZ1dHVyZSAoSkZGKSIsImljb25VcmwiOiJodHRwczovL3czYy1jY2cuZ2l0
+      aHViLmlvL3ZjLWVkL3BsdWdmZXN0LTEtMjAyMi9pbWFnZXMvSkZGX0xvZ29Mb2
+      NrdXAucG5nIiwiaW1hZ2UiOiJodHRwczovL3czYy1jY2cuZ2l0aHViLmlvL3Zj
+      LWVkL3BsdWdmZXN0LTEtMjAyMi9pbWFnZXMvSkZGX0xvZ29Mb2NrdXAucG5nIn
+      0sIm5hbWUiOiJKRkYgeCB2Yy1lZHUgUGx1Z0Zlc3QgMiIsImRlc2NyaXB0aW9u
+      IjoiTUFUVFEncyBzdWJtaXNzaW9uIGZvciBKRkYgUGx1Z2Zlc3QgMiIsImNyZW
+      RlbnRpYWxCcmFuZGluZyI6eyJiYWNrZ3JvdW5kQ29sb3IiOiIjNDY0YzQ5In0s
+      InZhbGlkRnJvbSI6IjIwMjMtMDEtMjVUMTY6NTg6MDYuMjkyWiIsImNyZWRlbn
+      RpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmtleTp6Nk1rcWdrTHJSeUxnNmJxazI3
+      ZGp3YmJhUVdnYVNZZ0ZWQ0txOVlLeFpiTmtwVnYiLCJ0eXBlIjpbIkFjaGlldm
+      VtZW50U3ViamVjdCJdLCJfc2QiOlsiZ0RGVzg2SGNNSDJxS2t6QWZxTEM4LWRa
+      Mm9WOUFFWlBWQ211NlA0cThjYyJdfSwiaWF0IjoxNjk4MTUxNTMyLCJjbmYiOn
+      sia2lkIjoiZGlkOmtleTp6Nk1rcWdrTHJSeUxnNmJxazI3ZGp3YmJhUVdnYVNZ
+      Z0ZWQ0txOVlLeFpiTmtwVnYjejZNa3Fna0xyUnlMZzZicWsyN2Rqd2JiYVFXZ2
+      FTWWdGVkNLcTlZS3haYk5rcFZ2In0sIl9zZF9hbGciOiJzaGEtMjU2In0.WQXj
+      JmDyd5LpcgNAQJdycjyk1xIUJ7n184CU-V-MrhpgvmzYRrdUp1sVc4hjpebZN5
+      jMYpvBWdSYwcavh5TfXg~WyJjMkZzZEEiLCJhY2hpZXZlbWVudCIseyJpZCI6
+      InVybjp1dWlkOmJkNmQ5MzE2LWY3YWUtNDA3My1hMWU1LTJmN2Y1YmQyMjkyMi
+      IsIm5hbWUiOiJKRkYgeCB2Yy1lZHUgUGx1Z0Zlc3QgMiBJbnRlcm9wZXJhYmls
+      aXR5IiwidHlwZSI6WyJBY2hpZXZlbWVudCJdLCJpbWFnZSI6eyJpZCI6Imh0dH
+      BzOi8vdzNjLWNjZy5naXRodWIuaW8vdmMtZWQvcGx1Z2Zlc3QtMi0yMDIyL2lt
+      YWdlcy9KRkYtVkMtRURVLVBMVUdGRVNUMi1iYWRnZS1pbWFnZS5wbmciLCJ0eX
+      BlIjoiSW1hZ2UifSwiY3JpdGVyaWEiOnsidHlwZSI6IkNyaXRlcmlhIiwibmFy
+      cmF0aXZlIjoiU29sdXRpb25zIHByb3ZpZGVycyBlYXJuZWQgdGhpcyBiYWRnZS
+      BieSBkZW1vbnN0cmF0aW5nIGludGVyb3BlcmFiaWxpdHkgYmV0d2VlbiBtdWx0
+      aXBsZSBwcm92aWRlcnMgYmFzZWQgb24gdGhlIE9CdjMgY2FuZGlkYXRlIGZpbm
+      FsIHN0YW5kYXJkLCB3aXRoIHNvbWUgYWRkaXRpb25hbCByZXF1aXJlZCBmaWVs
+      ZHMuIENyZWRlbnRpYWwgaXNzdWVycyBlYXJuaW5nIHRoaXMgYmFkZ2Ugc3VjY2
+      Vzc2Z1bGx5IGlzc3VlZCBhIGNyZWRlbnRpYWwgaW50byBhdCBsZWFzdCB0d28g
+      d2FsbGV0cy4gIFdhbGxldCBpbXBsZW1lbnRlcnMgZWFybmluZyB0aGlzIGJhZG
+      dlIHN1Y2Nlc3NmdWxseSBkaXNwbGF5ZWQgY3JlZGVudGlhbHMgaXNzdWVkIGJ5
+      IGF0IGxlYXN0IHR3byBkaWZmZXJlbnQgY3JlZGVudGlhbCBpc3N1ZXJzLiJ9LC
+      JkZXNjcmlwdGlvbiI6IlRoaXMgY3JlZGVudGlhbCBzb2x1dGlvbiBzdXBwb3J0
+      cyB0aGUgdXNlIG9mIE9CdjMgYW5kIHczYyBWZXJpZmlhYmxlIENyZWRlbnRpYW
+      xzIGFuZCBpcyBpbnRlcm9wZXJhYmxlIHdpdGggYXQgbGVhc3QgdHdvIG90aGVy
+      IHNvbHV0aW9ucy4gIFRoaXMgd2FzIGRlbW9uc3RyYXRlZCBzdWNjZXNzZnVsbH
+      kgZHVyaW5nIEpGRiB4IHZjLWVkdSBQbHVnRmVzdCAyLiJ9XQ~"
+    }
+  ]
+}

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -2186,6 +2186,22 @@ regulation), the Credential Issuer should properly authenticate the Wallet and e
   </front>
 </reference>
 
+<reference anchor="VC_JOSE_COSE" target="https://www.w3.org/TR/2025/REC-vc-jose-cose-20250515/">
+  <front>
+    <title>Securing Verifiable Credentials using JOSE and COSE</title>
+    <author fullname="Michael B. Jones">
+      <organization>Self-Issued Consulting</organization>
+    </author>
+    <author fullname="Michael Prorock">
+      <organization>Mesur.io</organization>
+    </author>
+    <author fullname="Gabe Cohen">
+      <organization>Block</organization>
+    </author>
+   <date day="15" month="May" year="2025"/>
+  </front>
+</reference>
+
 <reference anchor="VC_Data_Integrity" target="https://www.w3.org/TR/2025/REC-vc-data-integrity-20250515/">
   <front>
     <title>Verifiable Credential Data Integrity 1.0</title>
@@ -2627,6 +2643,92 @@ The definitions in (#credential-response-jwt-vc-json) apply for Credentials of t
 #### Interactive Authorization Endpoint Binding
 
 The definitions in (#iae-binding-jwt-vc-json) apply to the Credentials of this format.
+
+## W3C Verifiable Credentials Data Model 2.0
+
+The W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] specification defines verifiable credentials that can be secured using various methods. The [@VC_JOSE_COSE] specification defines how to secure credentials and presentations conforming to [@VC_DATA_2.0] using JOSE and COSE, including the format identifiers and securing mechanisms for JWT and SD-JWT.
+
+This specification differentiates between the following two Credential Formats for W3C VCDM 2.0:
+
+* VC secured as a JWT (`vc+jwt`)
+* VC secured as an SD-JWT (`vc+sd-jwt`)
+
+Distinct Credential Format Identifiers, extension parameters/claims, and processing rules are defined for each of the above-mentioned Credential Formats.
+
+### VC Secured as a JWT {#vc-jwt}
+
+#### Format Identifier
+
+The Credential Format Identifier is `vc+jwt`. This format identifier is registered by the [@VC_JOSE_COSE] specification.
+
+When the `format` value is `vc+jwt`, the Credential conforms to the W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] and is secured as a JWT as defined in [@VC_JOSE_COSE].
+
+#### Credential Issuer Metadata {#server-metadata-vc-jwt}
+
+Cryptographic algorithm identifiers used in the `credential_signing_alg_values_supported` parameter are case sensitive strings and SHOULD be one of those JWS Algorithm Names defined in [@IANA.JOSE].
+
+The following additional Credential Issuer metadata parameters are defined for this Credential Format for use in the `credential_configurations_supported` parameter, in addition to those defined in (#credential-issuer-parameters).
+
+* `credential_definition`: REQUIRED. Object containing the detailed description of the Credential type. It consists of the following parameter:
+  * `type`: REQUIRED. Array designating the types a certain Credential type supports, according to [@VC_DATA_2.0], Section 4.5.
+
+The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential Format `vc+jwt`:
+
+<{{examples/credential_metadata_vc_jwt.json}}
+
+#### Authorization Details {#authorization-vc-jwt}
+
+The following is a non-normative example of an authorization details object with Credential Format `vc+jwt`:
+
+<{{examples/authorization_details_vc_jwt.json}}
+
+#### Credential Response {#credential-response-vc-jwt}
+
+The value of the `credential` claim in the Credential Response MUST be a string that is a JWT-secured W3C VCDM 2.0 Verifiable Credential. Credentials of this format are already a sequence of base64url-encoded values separated by period characters and MUST NOT be re-encoded.
+
+The following is a non-normative example of a Credential Response with Credential Format `vc+jwt` (with line breaks within values for display purposes only):
+
+<{{examples/credential_response_vc_jwt.txt}}
+
+#### Interactive Authorization Endpoint Binding {#iae-binding-vc-jwt}
+
+To bind the Interactive Authorization Endpoint to a Verifiable Presentation using the Credential Format defined in this section, when the presentation is secured as a JWT (`vp+jwt`) as defined in [@VC_JOSE_COSE], the Verifiable Credential in the presentation is contained in an `EnvelopedVerifiableCredential` as defined in [@VC_DATA_2.0]. The `aud` claim value in the Verifiable Presentation JWT MUST be set to the Interactive Authorization Endpoint, prefixed with `iae:` (e.g., `iae:https://example.com/iae`).
+
+### VC Secured as an SD-JWT {#vc-sd-jwt}
+
+#### Format Identifier
+
+The Credential Format Identifier is `vc+sd-jwt`. This format identifier is registered by the [@VC_JOSE_COSE] specification.
+
+When the `format` value is `vc+sd-jwt`, the Credential conforms to the W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] and is secured as an SD-JWT as defined in [@VC_JOSE_COSE].
+
+#### Credential Issuer Metadata {#server-metadata-vc-sd-jwt}
+
+The definitions in (#server-metadata-vc-jwt) apply for metadata of Credentials of this type as well.
+
+The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential Format `vc+sd-jwt`:
+
+<{{examples/credential_metadata_vc_sd_jwt.json}}
+
+#### Authorization Details {#authorization-vc-sd-jwt}
+
+The definitions in (#authorization-vc-jwt) apply for Credentials of this type as well.
+
+The following is a non-normative example of an authorization details object with Credential Format `vc+sd-jwt`:
+
+<{{examples/authorization_details_vc_sd_jwt.json}}
+
+#### Credential Response {#credential-response-vc-sd-jwt}
+
+The value of the `credential` claim in the Credential Response MUST be a string that is an SD-JWT-secured W3C VCDM 2.0 Verifiable Credential. Credentials of this format are already suitable for transfer and, therefore, they need not and MUST NOT be re-encoded.
+
+The following is a non-normative example of a Credential Response with Credential Format `vc+sd-jwt` (with line breaks within values for display purposes only):
+
+<{{examples/credential_response_vc_sd_jwt.txt}}
+
+#### Interactive Authorization Endpoint Binding {#iae-binding-vc-sd-jwt}
+
+To bind the Interactive Authorization Endpoint to a Verifiable Presentation using the Credential Format defined in this section, when the presentation is secured as an SD-JWT (`vp+sd-jwt`) as defined in [@VC_JOSE_COSE], the Verifiable Credential in the presentation is contained in an `EnvelopedVerifiableCredential` as defined in [@VC_DATA_2.0]. The `aud` claim value in the Key Binding JWT MUST be set to the Interactive Authorization Endpoint, prefixed with `iae:` (e.g., `iae:https://example.com/iae`).
 
 ## Mobile Documents or mdocs (ISO/IEC 18013) {#mdocs}
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -2644,92 +2644,6 @@ The definitions in (#credential-response-jwt-vc-json) apply for Credentials of t
 
 The definitions in (#iae-binding-jwt-vc-json) apply to the Credentials of this format.
 
-## W3C Verifiable Credentials Data Model 2.0
-
-The W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] specification defines verifiable credentials that can be secured using various methods. The [@VC_JOSE_COSE] specification defines how to secure credentials and presentations conforming to [@VC_DATA_2.0] using JOSE and COSE, including the format identifiers and securing mechanisms for JWT and SD-JWT.
-
-This specification differentiates between the following two Credential Formats for W3C VCDM 2.0:
-
-* VC secured as a JWT (`vc+jwt`)
-* VC secured as an SD-JWT (`vc+sd-jwt`)
-
-Distinct Credential Format Identifiers, extension parameters/claims, and processing rules are defined for each of the above-mentioned Credential Formats.
-
-### VC Secured as a JWT {#vc-jwt}
-
-#### Format Identifier
-
-The Credential Format Identifier is `vc+jwt`. This format identifier is registered by the [@VC_JOSE_COSE] specification.
-
-When the `format` value is `vc+jwt`, the Credential conforms to the W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] and is secured as a JWT as defined in [@VC_JOSE_COSE].
-
-#### Credential Issuer Metadata {#server-metadata-vc-jwt}
-
-Cryptographic algorithm identifiers used in the `credential_signing_alg_values_supported` parameter are case sensitive strings and SHOULD be one of those JWS Algorithm Names defined in [@IANA.JOSE].
-
-The following additional Credential Issuer metadata parameters are defined for this Credential Format for use in the `credential_configurations_supported` parameter, in addition to those defined in (#credential-issuer-parameters).
-
-* `credential_definition`: REQUIRED. Object containing the detailed description of the Credential type. It consists of the following parameter:
-  * `type`: REQUIRED. Array designating the types a certain Credential type supports, according to [@VC_DATA_2.0], Section 4.5.
-
-The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential Format `vc+jwt`:
-
-<{{examples/credential_metadata_vc_jwt.json}}
-
-#### Authorization Details {#authorization-vc-jwt}
-
-The following is a non-normative example of an authorization details object with Credential Format `vc+jwt`:
-
-<{{examples/authorization_details_vc_jwt.json}}
-
-#### Credential Response {#credential-response-vc-jwt}
-
-The value of the `credential` claim in the Credential Response MUST be a string that is a JWT-secured W3C VCDM 2.0 Verifiable Credential. Credentials of this format are already a sequence of base64url-encoded values separated by period characters and MUST NOT be re-encoded.
-
-The following is a non-normative example of a Credential Response with Credential Format `vc+jwt` (with line breaks within values for display purposes only):
-
-<{{examples/credential_response_vc_jwt.txt}}
-
-#### Interactive Authorization Endpoint Binding {#iae-binding-vc-jwt}
-
-To bind the Interactive Authorization Endpoint to a Verifiable Presentation using the Credential Format defined in this section, when the presentation is secured as a JWT (`vp+jwt`) as defined in [@VC_JOSE_COSE], the Verifiable Credential in the presentation is contained in an `EnvelopedVerifiableCredential` as defined in [@VC_DATA_2.0]. The `aud` claim value in the Verifiable Presentation JWT MUST be set to the Interactive Authorization Endpoint, prefixed with `iae:` (e.g., `iae:https://example.com/iae`).
-
-### VC Secured as an SD-JWT {#vc-sd-jwt}
-
-#### Format Identifier
-
-The Credential Format Identifier is `vc+sd-jwt`. This format identifier is registered by the [@VC_JOSE_COSE] specification.
-
-When the `format` value is `vc+sd-jwt`, the Credential conforms to the W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] and is secured as an SD-JWT as defined in [@VC_JOSE_COSE].
-
-#### Credential Issuer Metadata {#server-metadata-vc-sd-jwt}
-
-The definitions in (#server-metadata-vc-jwt) apply for metadata of Credentials of this type as well.
-
-The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential Format `vc+sd-jwt`:
-
-<{{examples/credential_metadata_vc_sd_jwt.json}}
-
-#### Authorization Details {#authorization-vc-sd-jwt}
-
-The definitions in (#authorization-vc-jwt) apply for Credentials of this type as well.
-
-The following is a non-normative example of an authorization details object with Credential Format `vc+sd-jwt`:
-
-<{{examples/authorization_details_vc_sd_jwt.json}}
-
-#### Credential Response {#credential-response-vc-sd-jwt}
-
-The value of the `credential` claim in the Credential Response MUST be a string that is an SD-JWT-secured W3C VCDM 2.0 Verifiable Credential. Credentials of this format are already suitable for transfer and, therefore, they need not and MUST NOT be re-encoded.
-
-The following is a non-normative example of a Credential Response with Credential Format `vc+sd-jwt` (with line breaks within values for display purposes only):
-
-<{{examples/credential_response_vc_sd_jwt.txt}}
-
-#### Interactive Authorization Endpoint Binding {#iae-binding-vc-sd-jwt}
-
-To bind the Interactive Authorization Endpoint to a Verifiable Presentation using the Credential Format defined in this section, when the presentation is secured as an SD-JWT (`vp+sd-jwt`) as defined in [@VC_JOSE_COSE], the Verifiable Credential in the presentation is contained in an `EnvelopedVerifiableCredential` as defined in [@VC_DATA_2.0]. The `aud` claim value in the Key Binding JWT MUST be set to the Interactive Authorization Endpoint, prefixed with `iae:` (e.g., `iae:https://example.com/iae`).
-
 ## Mobile Documents or mdocs (ISO/IEC 18013) {#mdocs}
 
 This section defines a Credential Format Profile for credentials that conform to the mobile document (mdoc) format specified in ISO/IEC 18013-5 [@ISO.18013-5].
@@ -2937,6 +2851,92 @@ The following is a non-normative example of a Credential Response containing a C
 ### Interactive Authorization Endpoint Binding {#iae-binding-sd-jwt-vc}
 
 To bind the Interactive Authorization Endpoint to a Verifiable Presentation using the Credential Format defined in this section, the `aud` claim in the Key Binding JWT MUST be set to the derived Origin (as defined in (#iae-require-presentation)) of the Interactive Authorization Endpoint, prefixed with `iae:` (e.g., `iae:https://example.com`).
+
+## W3C Verifiable Credentials Data Model 2.0
+
+The W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] specification defines verifiable credentials that can be secured using various methods. The [@VC_JOSE_COSE] specification defines how to secure credentials and presentations conforming to [@VC_DATA_2.0] using JOSE and COSE, including the format identifiers and securing mechanisms for JWT and SD-JWT.
+
+This specification differentiates between the following two Credential Formats for W3C VCDM 2.0:
+
+* VC secured as a JWT (`vc+jwt`)
+* VC secured as an SD-JWT (`vc+sd-jwt`)
+
+Distinct Credential Format Identifiers, extension parameters/claims, and processing rules are defined for each of the above-mentioned Credential Formats.
+
+### VC Secured as a JWT {#vc-jwt}
+
+#### Format Identifier
+
+The Credential Format Identifier is `vc+jwt`. This format identifier is registered by the [@VC_JOSE_COSE] specification.
+
+When the `format` value is `vc+jwt`, the Credential conforms to the W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] and is secured as a JWT as defined in [@VC_JOSE_COSE].
+
+#### Credential Issuer Metadata {#server-metadata-vc-jwt}
+
+Cryptographic algorithm identifiers used in the `credential_signing_alg_values_supported` parameter are case sensitive strings and SHOULD be one of those JWS Algorithm Names defined in [@IANA.JOSE].
+
+The following additional Credential Issuer metadata parameters are defined for this Credential Format for use in the `credential_configurations_supported` parameter, in addition to those defined in (#credential-issuer-parameters).
+
+* `credential_definition`: REQUIRED. Object containing the detailed description of the Credential type. It consists of the following parameter:
+  * `type`: REQUIRED. Array designating the types a certain Credential type supports, according to [@VC_DATA_2.0], Section 4.5.
+
+The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential Format `vc+jwt`:
+
+<{{examples/credential_metadata_vc_jwt.json}}
+
+#### Authorization Details {#authorization-vc-jwt}
+
+The following is a non-normative example of an authorization details object with Credential Format `vc+jwt`:
+
+<{{examples/authorization_details_vc_jwt.json}}
+
+#### Credential Response {#credential-response-vc-jwt}
+
+The value of the `credential` claim in the Credential Response MUST be a string that is a JWT-secured W3C VCDM 2.0 Verifiable Credential. Credentials of this format are already a sequence of base64url-encoded values separated by period characters and MUST NOT be re-encoded.
+
+The following is a non-normative example of a Credential Response with Credential Format `vc+jwt` (with line breaks within values for display purposes only):
+
+<{{examples/credential_response_vc_jwt.txt}}
+
+#### Interactive Authorization Endpoint Binding {#iae-binding-vc-jwt}
+
+To bind the Interactive Authorization Endpoint to a Verifiable Presentation using the Credential Format defined in this section, when the presentation is secured as a JWT (`vp+jwt`) as defined in [@VC_JOSE_COSE], the Verifiable Credential in the presentation is contained in an `EnvelopedVerifiableCredential` as defined in [@VC_DATA_2.0]. The `aud` claim value in the Verifiable Presentation JWT MUST be set to the Interactive Authorization Endpoint, prefixed with `iae:` (e.g., `iae:https://example.com/iae`).
+
+### VC Secured as an SD-JWT {#vc-sd-jwt}
+
+#### Format Identifier
+
+The Credential Format Identifier is `vc+sd-jwt`. This format identifier is registered by the [@VC_JOSE_COSE] specification.
+
+When the `format` value is `vc+sd-jwt`, the Credential conforms to the W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_2.0] and is secured as an SD-JWT as defined in [@VC_JOSE_COSE].
+
+#### Credential Issuer Metadata {#server-metadata-vc-sd-jwt}
+
+The definitions in (#server-metadata-vc-jwt) apply for metadata of Credentials of this type as well.
+
+The following is a non-normative example of an object containing the `credential_configurations_supported` parameter for Credential Format `vc+sd-jwt`:
+
+<{{examples/credential_metadata_vc_sd_jwt.json}}
+
+#### Authorization Details {#authorization-vc-sd-jwt}
+
+The definitions in (#authorization-vc-jwt) apply for Credentials of this type as well.
+
+The following is a non-normative example of an authorization details object with Credential Format `vc+sd-jwt`:
+
+<{{examples/authorization_details_vc_sd_jwt.json}}
+
+#### Credential Response {#credential-response-vc-sd-jwt}
+
+The value of the `credential` claim in the Credential Response MUST be a string that is an SD-JWT-secured W3C VCDM 2.0 Verifiable Credential. Credentials of this format are already suitable for transfer and, therefore, they need not and MUST NOT be re-encoded.
+
+The following is a non-normative example of a Credential Response with Credential Format `vc+sd-jwt` (with line breaks within values for display purposes only):
+
+<{{examples/credential_response_vc_sd_jwt.txt}}
+
+#### Interactive Authorization Endpoint Binding {#iae-binding-vc-sd-jwt}
+
+To bind the Interactive Authorization Endpoint to a Verifiable Presentation using the Credential Format defined in this section, when the presentation is secured as an SD-JWT (`vp+sd-jwt`) as defined in [@VC_JOSE_COSE], the Verifiable Credential in the presentation is contained in an `EnvelopedVerifiableCredential` as defined in [@VC_DATA_2.0]. The `aud` claim value in the Key Binding JWT MUST be set to the Interactive Authorization Endpoint, prefixed with `iae:` (e.g., `iae:https://example.com/iae`).
 
 # Claims Description 
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -52,7 +52,7 @@ This specification defines an API for the issuance of Verifiable Credentials.
 
 # Introduction
 
-This specification defines an OAuth-protected API for the issuance of Verifiable Credentials. Credentials can be of any format, including, but not limited to, IETF SD-JWT VC [@I-D.ietf-oauth-sd-jwt-vc], ISO mdoc [@ISO.18013-5], and W3C VCDM [@VC_DATA].
+This specification defines an OAuth-protected API for the issuance of Verifiable Credentials. Credentials can be of any format, including, but not limited to, IETF SD-JWT VC [@I-D.ietf-oauth-sd-jwt-vc], ISO mdoc [@ISO.18013-5], W3C VCDM 1.1 [@VC_DATA], and W3C VCDM 2.0 [@VC_DATA_2.0].
 
 Verifiable Credentials are very similar to identity assertions, like ID Tokens in OpenID Connect [@OpenID.Core], in that they allow a Credential Issuer to assert End-User claims. A Verifiable Credential follows a pre-defined schema (the Credential type) and MAY be bound to a certain Holder, e.g., through Cryptographic Key Binding. Verifiable Credentials can be securely presented for the End-User to the RP, without the involvement of the Credential Issuer.
 
@@ -80,7 +80,7 @@ Credential Format:
 :  Data Model used to create and represent Credential information. This format defines how various pieces of data within a Verifiable Credential are organized and encoded, ensuring that the Verifiable Credential can be consistently understood, processed, and verified by different systems. The exact parameters required to use a Credential Format in the context of this specification are defined in the Credential Format Profile. Definitions of Credential Formats is out of scope for this specification. Examples for Credential Formats are IETF SD-JWT VC [@I-D.ietf-oauth-sd-jwt-vc], ISO mdoc [@ISO.18013-5], and W3C VCDM [@VC_DATA].
 
 Credential Format Profile:
-:  Set of parameters specific to individual Credential Formats. This specification provides Credential Format Profiles for IETF SD-JWT VC [@I-D.ietf-oauth-sd-jwt-vc], ISO mdoc [@ISO.18013-5], and W3C VCDM [@VC_DATA], which can be found in the section (#format-profiles). Additionally, other specifications or deployments can define their own Credential Format Profiles by utilizing the extension points defined in this specification.
+:  Set of parameters specific to individual Credential Formats. This specification provides Credential Format Profiles for IETF SD-JWT VC [@I-D.ietf-oauth-sd-jwt-vc], ISO mdoc [@ISO.18013-5], W3C VCDM 1.1 [@VC_DATA], and W3C VCDM 2.0 [@VC_DATA_2.0], which can be found in the section (#format-profiles). Additionally, other specifications or deployments can define their own Credential Format Profiles by utilizing the extension points defined in this specification.
 
 Credential Format Identifier:
 :  An identifier to denote a specific Credential Format in the context of this specification. This identifier implies the use of parameters specific to the respective Credential Format Profile.
@@ -159,7 +159,7 @@ An End-User typically authorizes the issuance of Credentials with a specific Cre
 This specification is Credential Format agnostic and allows implementers to leverage specific capabilities of Credential Formats of their choice.
 To this end, extension points to add Credential Format specific parameters in the Credential Issuer metadata, Credential Offer, Authorization Request, and Credential Request are defined.
 
-Credential Format Profiles for IETF SD-JWT VC [@I-D.ietf-oauth-sd-jwt-vc], ISO mdoc [@ISO.18013-5], and W3C VCDM [@VC_DATA] are specified in (#format-profiles).
+Credential Format Profiles for IETF SD-JWT VC [@I-D.ietf-oauth-sd-jwt-vc], ISO mdoc [@ISO.18013-5], W3C VCDM 1.1 [@VC_DATA], and W3C VCDM 2.0 [@VC_DATA_2.0], are specified in (#format-profiles).
 Other specifications or deployments can define their own Credential Format Profiles using the above-mentioned extension points.
 
 ### Batch Credential Issuance
@@ -2515,13 +2515,11 @@ This specification defines several extension points to accommodate the differenc
 
 This section defines Credential Format Profiles for a few of the commonly used Credential Formats. Other specifications or deployments can define their own Credential Format Profiles. It is RECOMMENDED that new Credential Format Profiles use the media type of the particular Credential Format for the Credential Format Identifier.
 
-
-
-## W3C Verifiable Credentials
+## W3C Verifiable Credentials Data Model 1.1
 
 Sections 6.1 and 6.2 of [@VC_DATA] define how Verifiable Credentials MAY or MAY NOT use JSON-LD [@JSON-LD]. As acknowledged in Section 4.1 of [@VC_DATA], implementations can behave differently regarding processing of the `@context` property whether JSON-LD is used or not.
 
-This specification therefore differentiates between the following three Credential Formats for W3C Verifiable Credentials:
+This specification therefore differentiates between the following three Credential Formats for W3C Verifiable Credentials 1.1:
 
 * VC signed as a JWT, not using JSON-LD (`jwt_vc_json`)
 * VC signed as a JWT, using JSON-LD (`jwt_vc_json-ld`)


### PR DESCRIPTION
This partially addresses #194, but only focuses on the VCDM 2.0 with JOSE (vc+jwt and vc+sd-jwt), but doesn't include the JSON-LD-based or CBOR based variants.

It might make sense to add them all at once, but we have only implemented / experimented with the JOSE-based variants.

Since there was already an issue where contribution was asked, I decided to create a PR directly instead of opening the discussion in the issue again.

Based on comments from @jogu in #194 I added a new profile rather than extending the existing VCDM profile.