### PR TITLE
Make auth_session optional if other binding mechanism exists.

### DIFF
--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -808,9 +808,13 @@ Depending on this assessment, the response from the Interactive Authorization En
 ### Interaction Required Response {#iae-interaction-required-response}
 
 By setting `status` to `require_interaction` in the response, the Authorization Server requests an additional user interaction.
-In this case, the following keys MUST be present in the response as well:
+In this case, the following key MUST be present in the response as well:
 
 * `type`: REQUIRED. String indicating which type of interaction is required, as defined below. The Authorization Server MUST NOT set this to a value that was not included in the `interaction_types_supported` parameter sent by the Wallet.
+
+The Authorization Server MUST provide a mechanism to associate the next request by this Wallet with the ongoing authorization request sequence.
+If no other mechanism to associate the next request by this Wallet with the ongoing authorization request sequence is defined by the type of interaction, the following key MUST be present in the response as well:
+
 * `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
 
 The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
@@ -825,6 +829,8 @@ If `type` is set to `openid4vp_presentation`, as shown in the following example,
 
 * The `response_mode` MUST be either `iae-post` for unencrypted responses or `iae-post.jwt` for encrypted responses. These modes are used to indicate to the Wallet to return the response back to the same Interactive Authorization Endpoint.
 * If `expected_origins` is present, it MUST contain only the derived Origin of the Interactive Authorization Endpoint as defined in Section 4 in [@RFC6454]. For example, the derived Origin from `https://example.com/iae` is `https://example.com`.
+
+The response MUST include the key `auth_session` to associate the next request by this Wallet with the ongoing authorization request sequence.
 
 The following is a non-normative example of an unsigned Authorization Request:
 
@@ -939,6 +945,8 @@ In this case, the Authorization server MUST include the key `request_uri` in the
 The Wallet MUST use the `request_uri` value to build an Authorization Request as defined in Section 4 of [@!RFC9126] and complete the rest of the authorization process as defined there.
 The Authorization Server MAY include the `expires_in` key as defined in [@!RFC9126].
 
+Since the `request_uri` allows the Authorization Server to associate the Authorization Request with the ongoing authorization request sequence, no `auth_session` is needed.
+
 Non-normative Example:
 
 ```
@@ -975,6 +983,7 @@ It is RECOMMENDED to use this extension point instead of modifying the OAuth pro
 See (#iae-security) for additional security considerations.
 
 In the following non-normative example, this extension point is used to read the Betelgeuse Intergalactic ID card through an NFC interface in the Wallet. A token called `biic_token` is used to start the process.
+It is assumed that the `biic_token` is used by the Authorization Server to associate the next request by this Wallet with the ongoing authorization request sequence, and no `auth_session` is thus needed.
 
 ```
 HTTP/1.1 200 OK

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -945,7 +945,7 @@ In this case, the Authorization server MUST include the key `request_uri` in the
 The Wallet MUST use the `request_uri` value to build an Authorization Request as defined in Section 4 of [@!RFC9126] and complete the rest of the authorization process as defined there.
 The Authorization Server MAY include the `expires_in` key as defined in [@!RFC9126].
 
-Since the `request_uri` allows the Authorization Server to associate the Authorization Request with the ongoing authorization request sequence, no `auth_session` is needed.
+Since the `request_uri` allows the Authorization Server to associate the Authorization Request with the ongoing authorization request sequence, the Authorization Server MUST omit `auth_session` parameter in the response. The `auth_session` will be returned in the redirect back to the Wallet if required.
 
 Non-normative Example:
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -813,9 +813,14 @@ In this case, the following key MUST be present in the response as well:
 * `type`: REQUIRED. String indicating which type of interaction is required, as defined below. The Authorization Server MUST NOT set this to a value that was not included in the `interaction_types_supported` parameter sent by the Wallet.
 
 The Authorization Server MUST provide a mechanism to associate the next request by this Wallet with the ongoing authorization request sequence.
-If no other mechanism to associate the next request by this Wallet with the ongoing authorization request sequence is defined by the type of interaction, the following key MUST be present in the response as well:
+The following key MAY be present in the response to provide such a mechanism:
 
 * `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
+
+A definition of a custom type of interaction MUST include exactly one of the following:
+
+1. A normative requirement that the `auth_session` key MUST be included in the Interaction Required Response.
+2. A definition of a mechanism to associate the next request by the Wallet with the ongoing authorization request sequence.
 
 The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -815,7 +815,7 @@ In this case, the following key MUST be present in the response as well:
 The Authorization Server MUST provide a mechanism to associate the next request by this Wallet with the ongoing authorization request sequence.
 The following key MAY be present in the response to provide such a mechanism:
 
-* `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
+* `auth_session`: REQUIRED if specified by the interaction type. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
 
 A definition of a custom type of interaction MUST include exactly one of the following:
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -800,14 +800,7 @@ A definition of a custom type of interaction MUST include exactly one of the fol
 1. A normative requirement that the `auth_session` key MUST be included in the Interaction Required Response.
 2. A definition of a mechanism to associate the next request by the Wallet with the ongoing authorization request sequence.
 
-The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
-
-A definition of a custom type of interaction MUST include exactly one of the following:
-
-1. A normative requirement that the `auth_session` key MUST be included in the Interaction Required Response.
-2. A definition of a mechanism to associate the next request by the Wallet with the ongoing authorization request sequence.
-
-The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
+The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Authorization Challenge Endpoint.
 
 Additional keys are defined based on the type of interaction, as shown next.
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -791,9 +791,16 @@ In this case, the following keys MUST be present in the response as well:
 If a Wallet receives an `interaction_type_required` value that it does not support, it MUST abort the issuance process.
 
 The Authorization Server MUST provide a mechanism to associate the next request by this Wallet with the ongoing authorization request sequence.
-If no other mechanism to associate the next request by this Wallet with the ongoing authorization request sequence is defined by the type of interaction, the following key MUST be present in the response as well:
+The following key MAY be present in the response to provide such a mechanism:
 
 * `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
+
+A definition of a custom type of interaction MUST include exactly one of the following:
+
+1. A normative requirement that the `auth_session` key MUST be included in the Interaction Required Response.
+2. A definition of a mechanism to associate the next request by the Wallet with the ongoing authorization request sequence.
+
+The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
 
 A definition of a custom type of interaction MUST include exactly one of the following:
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -793,7 +793,7 @@ If a Wallet receives an `interaction_type_required` value that it does not suppo
 The Authorization Server MUST provide a mechanism to associate the next request by this Wallet with the ongoing authorization request sequence.
 The following key MAY be present in the response to provide such a mechanism:
 
-* `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
+* `auth_session`: REQUIRED if specified by the interaction type. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
 
 A definition of a custom type of interaction MUST include exactly one of the following:
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -793,7 +793,7 @@ If a Wallet receives an `interaction_type_required` value that it does not suppo
 The Authorization Server MUST provide a mechanism to associate the next request by this Wallet with the ongoing authorization request sequence.
 The following key MAY be present in the response to provide such a mechanism:
 
-* `auth_session`: REQUIRED if specified by the interaction type. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
+* `auth_session`: REQUIRED if specified by the interaction type. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each authorization challenge response.
 
 A definition of a custom type of interaction MUST include exactly one of the following:
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -783,14 +783,24 @@ The response to an Authorization Challenge Request is an HTTP message with the c
  3. an error as defined in Section 5.2.2 of [@!I-D.ietf-oauth-first-party-apps], including the additional error codes defined in (#ia-error-response).
 
 ### Interaction Required Response {#ia-interaction-required-response}
-
 By setting `error_code` to `insufficient_authorization` in the response with HTTP response code 401 `Unauthorized`, the Authorization Server requests an additional user interaction.
 In this case, the following keys MUST be present in the response as well:
 
 * `interaction_type_required`: REQUIRED. String indicating which type of interaction is required, as defined below. The Authorization Server MUST set this to a value that was included in the `interaction_types_supported` parameter sent by the Wallet. If the Authorization Server cannot fulfill the request using any of the supported types, it MUST reject the request with an Authorization Challenge Error Response, as defined in (#ia-error-response).
-* `auth_session`: REQUIRED. As defined in Section 5.2.2 of [@!I-D.ietf-oauth-first-party-apps]
 
 If a Wallet receives an `interaction_type_required` value that it does not support, it MUST abort the issuance process.
+
+The Authorization Server MUST provide a mechanism to associate the next request by this Wallet with the ongoing authorization request sequence.
+If no other mechanism to associate the next request by this Wallet with the ongoing authorization request sequence is defined by the type of interaction, the following key MUST be present in the response as well:
+
+* `auth_session`: REQUIRED. String containing a value that allows the Authorization Server to associate subsequent requests by this Wallet with the ongoing authorization request sequence. Wallets SHOULD treat this value as an opaque value. The value returned MUST be distinct for each interactive authorization response.
+
+A definition of a custom type of interaction MUST include exactly one of the following:
+
+1. A normative requirement that the `auth_session` key MUST be included in the Interaction Required Response.
+2. A definition of a mechanism to associate the next request by the Wallet with the ongoing authorization request sequence.
+
+The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Interactive Authorization Endpoint.
 
 Additional keys are defined based on the type of interaction, as shown next.
 
@@ -800,6 +810,8 @@ If `interaction_type_required` is set to `urn:openid:dcp:ia:openid4vp_presentati
 
 * The `response_mode` MUST be either `ia_post` for unencrypted responses or `ia_post.jwt` for encrypted responses. When the Wallet receives one of these response modes, it MUST send its response to the same Authorization Challenge Endpoint.
 * If `expected_origins` is present, it MUST contain only the derived Origin of the Authorization Challenge Endpoint as defined in Section 4 of [@RFC6454]. For example, the derived Origin from `https://example.com/authorize-challenge` is `https://example.com`.
+
+The response MUST include the key `auth_session` to associate the next request by this Wallet with the ongoing authorization request sequence.
 
 The following is a non-normative example of an unsigned Authorization Request:
 
@@ -916,6 +928,8 @@ The Wallet MUST only use a `request_uri` value once.
 Authorization servers SHOULD treat `request_uri` values as one-time use but MAY allow for duplicate requests due to a user reloading/refreshing their user agent. An expired request_uri MUST be rejected as invalid.
 The Authorization Server MAY include the `expires_in` key as defined in [@!RFC9126].
 
+Since the `request_uri` allows the Authorization Server to associate the Authorization Request with the ongoing authorization request sequence, no `auth_session` is needed.
+
 Non-normative Example:
 
 ```
@@ -953,6 +967,7 @@ It is RECOMMENDED to use this extension point instead of modifying the OAuth pro
 See (#ia-security) for additional security considerations.
 
 In the following non-normative example, this extension point is used to read the Betelgeuse Intergalactic ID card through an NFC interface in the Wallet. A token called `biic_token` is used to start the process.
+It is assumed that the `biic_token` is used by the Authorization Server to associate the next request by this Wallet with the ongoing authorization request sequence, and no `auth_session` is thus needed.
 
 ```
 HTTP/1.1 401 Unauthorized

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -928,7 +928,7 @@ The Wallet MUST only use a `request_uri` value once.
 Authorization servers SHOULD treat `request_uri` values as one-time use but MAY allow for duplicate requests due to a user reloading/refreshing their user agent. An expired request_uri MUST be rejected as invalid.
 The Authorization Server MAY include the `expires_in` key as defined in [@!RFC9126].
 
-Since the `request_uri` allows the Authorization Server to associate the Authorization Request with the ongoing authorization request sequence, no `auth_session` is needed.
+Since the `request_uri` allows the Authorization Server to associate the Authorization Request with the ongoing authorization request sequence, the Authorization Server MUST omit `auth_session` parameter in the response. The `auth_session` will be returned in the redirect back to the Wallet if required.
 
 Non-normative Example:
 

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -775,6 +775,7 @@ The following non-normative example shows a payload of a signed request object:
 In addition to the request parameters defined in Section 5.3 of [@!I-D.ietf-oauth-first-party-apps], the Wallet adds parameters that are in response to the interaction type the Authorization Server requested in the most recent response. The specific parameters are defined by each interaction type.
 
 ## Authorization Challenge Response
+
 Upon receiving an Authorization Challenge Request, the Authorization Server determines whether the Authorization Request is syntactically and semantically correct and whether the information provided by the Wallet so far is sufficient to grant authorization for the Credential issuance.
 The response to an Authorization Challenge Request is an HTTP message with the content type `application/json` and a JSON document in the body that indicates either
 
@@ -783,6 +784,7 @@ The response to an Authorization Challenge Request is an HTTP message with the c
  3. an error as defined in Section 5.2.2 of [@!I-D.ietf-oauth-first-party-apps], including the additional error codes defined in (#ia-error-response).
 
 ### Interaction Required Response {#ia-interaction-required-response}
+
 By setting `error_code` to `insufficient_authorization` in the response with HTTP response code 401 `Unauthorized`, the Authorization Server requests an additional user interaction.
 In this case, the following keys MUST be present in the response as well:
 
@@ -939,7 +941,6 @@ Cache-Control: no-store
 
 {
   "error": "insufficient_authorization",
-  "auth_session": "wxroVrBY2MCq4dDNGXACS",
   "interaction_type_required": "urn:openid:dcp:ia:auth_via_web",
   "request_uri": "urn:ietf:params:oauth:request_uri:6esc_11ACC5bwc014ltc14eY22c",
   "expires_in": 60
@@ -976,7 +977,6 @@ Cache-Control: no-store
 
 {
   "error": "insufficient_authorization",
-  "auth_session": "wxroVrBY2MCq4dDNGXACS",
   "interaction_type_required": "urn:galaxysdo:ia:betelgeuse_intergalactic_id_card",
   "biic_token": "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
 }

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -803,6 +803,7 @@ A definition of a custom type of interaction MUST include exactly one of the fol
 2. A definition of a mechanism to associate the next request by the Wallet with the ongoing authorization request sequence.
 
 The Wallet MUST include the most recently received `auth_session` in follow-up requests to the Authorization Challenge Endpoint.
+The Wallet MUST ignore the `auth_session` key when processing Interaction Required Responses for interaction types that do not specify a requirement to include the `auth_session` key.
 
 Additional keys are defined based on the type of interaction, as shown next.
 


### PR DESCRIPTION
The auth_session parameter is not needed in the all Interaction Required Responses since some interaction types already include a way to associate the next request with the ongoing auth sequence.

This makes the requirement for auth_session conditional on there not being some other mechanism for binding the request to the auth sequence.
It also adds a description of why the auth_session is not necessary in the redirect_to_web case and the custom example.

This is a suggestion to fix #690, but we could also go other ways.