### PR TITLE
Fix http reason phrase in deferred issuance 202 response example

### DIFF
--- a/1.0/openid-4-verifiable-credential-issuance-1_0.md
+++ b/1.0/openid-4-verifiable-credential-issuance-1_0.md
@@ -1149,7 +1149,7 @@ Content-Type: application/json
 The following is a non-normative example of a Deferred Credential Response, where the Credential Issuer still requires more time:
 
 ```
-HTTP/1.1 202 OK
+HTTP/1.1 202 Accepted
 Content-Type: application/json
 
 {

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -1556,7 +1556,7 @@ Content-Type: application/json
 The following is a non-normative example of a Deferred Credential Response, where the Credential Issuer still requires more time:
 
 ```
-HTTP/1.1 202 OK
+HTTP/1.1 202 Accepted
 Content-Type: application/json
 
 {


### PR DESCRIPTION
It was 'Ok' when it should be 'Accepted'. Fix example in both 1.0 and 1.1.