### PR TITLE
Remove any terminating `/` from the Credential Issuer Identifier when forming the Credential Issuer Metadata URL

### DIFF
--- a/1.0/openid-4-verifiable-credential-issuance-1_0.md
+++ b/1.0/openid-4-verifiable-credential-issuance-1_0.md
@@ -1309,9 +1309,9 @@ A Credential Issuer is identified by a case sensitive URL using the `https` sche
 
 The Credential Issuer's configuration can be retrieved using the Credential Issuer Identifier.
 
-Credential Issuers publishing metadata MUST make a JSON document available at the path formed by inserting the string `/.well-known/openid-credential-issuer` into the Credential Issuer Identifier between the host component and the path component, if any.
+Credential Issuers publishing metadata MUST make a JSON document available at the path formed by inserting the string `/.well-known/openid-credential-issuer` into the Credential Issuer Identifier between the host component and the path component, if any. If the Credential Issuer Identifier contains a path component, any terminating `/` MUST be removed before inserting `/.well-known/openid-credential-issuer`.
 
-For example, the metadata for the Credential Issuer Identifier `https://issuer.example.com/tenant` would be retrieved from `https://issuer.example.com/.well-known/openid-credential-issuer/tenant`. The metadata for the Credential Issuer Identifier `https://tenant.issuer.example.com` would be retrieved from `https://tenant.issuer.example.com/.well-known/openid-credential-issuer`.
+For example, the metadata for the Credential Issuer Identifier `https://issuer.example.com/tenant` would be retrieved from `https://issuer.example.com/.well-known/openid-credential-issuer/tenant`. The metadata for the Credential Issuer Identifier `https://issuer.example.com/tenant/` would also be retrieved from `https://issuer.example.com/.well-known/openid-credential-issuer/tenant`. The metadata for the Credential Issuer Identifier `https://tenant.issuer.example.com` would be retrieved from `https://tenant.issuer.example.com/.well-known/openid-credential-issuer`.
 
 Communication with the Credential Issuer Metadata Endpoint MUST utilize TLS.
 
@@ -3040,6 +3040,7 @@ The technology described in this specification was made available from contribut
 -19
 
    * Add security consideration on transaction code guessing
+   * add back removal of any terminating `/` from the Credential Issuer Identifier when forming the Credential Issuer Metadata URL
    
 -final
    

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -1688,7 +1688,7 @@ The Credential Issuer Metadata contains information on the Credential Issuer's t
 
 ### Credential Issuer Identifier {#credential-issuer-identifier}
 
-A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components. The Credential Issuer Identifier SHOULD NOT contain a terminating `/`.
+A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components.
 
 ### Credential Issuer Metadata Retrieval {#credential-issuer-wellknown}
 
@@ -3722,6 +3722,5 @@ The technology described in this specification was made available from contribut
    * add iana registration for an openid foundation urn
    * add optional metadata to the credential response
    * use OAuth 2.0 for First-Party Applications as basis for Interactive Authorization
-   * add recommendation that Credential Issuer Identifier should not terminate with `/`
    * add back removal of any terminating `/` from the Credential Issuer Identifier when forming the Credential Issuer Metadata URL
    * update IA HTTP response codes for consistency with First-Party Application draft-4

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -1688,7 +1688,7 @@ The Credential Issuer Metadata contains information on the Credential Issuer's t
 
 ### Credential Issuer Identifier {#credential-issuer-identifier}
 
-A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components.
+A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components. The Credential Issuer Identifier SHOULD not contain a terminating `/`.
 
 ### Credential Issuer Metadata Retrieval {#credential-issuer-wellknown}
 
@@ -3722,5 +3722,6 @@ The technology described in this specification was made available from contribut
    * add iana registration for an openid foundation urn
    * add optional metadata to the credential response
    * use OAuth 2.0 for First-Party Applications as basis for Interactive Authorization
+   * add recommendation that Credential Issuer Identifier should not terminate with `/`
    * add back removal of any terminating `/` from the Credential Issuer Identifier when forming the Credential Issuer Metadata URL
    * update IA HTTP response codes for consistency with First-Party Application draft-4

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -1688,15 +1688,15 @@ The Credential Issuer Metadata contains information on the Credential Issuer's t
 
 ### Credential Issuer Identifier {#credential-issuer-identifier}
 
-A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components. 
+A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components.
 
 ### Credential Issuer Metadata Retrieval {#credential-issuer-wellknown}
 
 The Credential Issuer's configuration can be retrieved using the Credential Issuer Identifier.
 
-Credential Issuers publishing metadata MUST make a JSON document available at the path formed by inserting the string `/.well-known/openid-credential-issuer` into the Credential Issuer Identifier between the host component and the path component, if any.
+Credential Issuers publishing metadata MUST make a JSON document available at the path formed by inserting the string `/.well-known/openid-credential-issuer` into the Credential Issuer Identifier between the host component and the path component, if any. If the Credential Issuer Identifier contains a path component, any terminating `/` MUST be removed before inserting `/.well-known/openid-credential-issuer`.
 
-For example, the metadata for the Credential Issuer Identifier `https://issuer.example.com/tenant` would be retrieved from `https://issuer.example.com/.well-known/openid-credential-issuer/tenant`. The metadata for the Credential Issuer Identifier `https://tenant.issuer.example.com` would be retrieved from `https://tenant.issuer.example.com/.well-known/openid-credential-issuer`.
+For example, the metadata for the Credential Issuer Identifier `https://issuer.example.com/tenant` would be retrieved from `https://issuer.example.com/.well-known/openid-credential-issuer/tenant`. The metadata for the Credential Issuer Identifier `https://issuer.example.com/tenant/` would also be retrieved from `https://issuer.example.com/.well-known/openid-credential-issuer/tenant`. The metadata for the Credential Issuer Identifier `https://tenant.issuer.example.com` would be retrieved from `https://tenant.issuer.example.com/.well-known/openid-credential-issuer`.
 
 Communication with the Credential Issuer Metadata Endpoint MUST utilize TLS.
 
@@ -3722,3 +3722,4 @@ The technology described in this specification was made available from contribut
    * add iana registration for an openid foundation urn
    * add optional metadata to the credential response
    * use OAuth 2.0 for First-Party Applications as basis for Interactive Authorization
+   * add back removal of any terminating `/` from the Credential Issuer Identifier when forming the Credential Issuer Metadata URL

--- a/1.1/openid-4-verifiable-credential-issuance-1_1.md
+++ b/1.1/openid-4-verifiable-credential-issuance-1_1.md
@@ -1688,7 +1688,7 @@ The Credential Issuer Metadata contains information on the Credential Issuer's t
 
 ### Credential Issuer Identifier {#credential-issuer-identifier}
 
-A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components.
+A Credential Issuer is identified by a case sensitive URL using the `https` scheme that contains scheme, host and, optionally, port number and path components, but no query or fragment components. The Credential Issuer Identifier SHOULD NOT contain a terminating `/`.
 
 ### Credential Issuer Metadata Retrieval {#credential-issuer-wellknown}
 
@@ -3722,5 +3722,6 @@ The technology described in this specification was made available from contribut
    * add iana registration for an openid foundation urn
    * add optional metadata to the credential response
    * use OAuth 2.0 for First-Party Applications as basis for Interactive Authorization
+   * add recommendation that Credential Issuer Identifier should not terminate with `/`
    * add back removal of any terminating `/` from the Credential Issuer Identifier when forming the Credential Issuer Metadata URL
    * update IA HTTP response codes for consistency with First-Party Application draft-4


### PR DESCRIPTION
Closes #744 

My observations while building this PR:
- the actual cleanest approach to this would be to forbid trailing slashes for the Credential Issuer Identifier in the first place
  - however, this is more of a breaking change and not aligned with RFC8414, which likely must have overseen this more elegant solution, as it prevents this edge case at the AS/RS side, instead of at client parsing
  - we still could add this as a recommendation, if there is appetite
- RFC8414 is also missing an example for the trailing slash, which in my opinion is important to highlight, so I added another example into the text that actually showcases the rule that is re-added in this PR