### PR TITLE
Add build rules for S2S draft

### DIFF
--- a/.github/workflows/Build-OID4VCI.yml
+++ b/.github/workflows/Build-OID4VCI.yml
@@ -21,10 +21,16 @@ jobs:
                 docker run \
                 -v /${{ github.workspace }}/1.1:/data danielfett/markdown2rfc \
                 openid-4-verifiable-credential-issuance-1_1.md
+          - name: s2s Run the build process with Docker
+            run: |
+                docker run \
+                -v /${{ github.workspace }}/s2s:/data danielfett/markdown2rfc \
+                openid-4-verifiable-credential-issuance-server-2-server.md
           - name: rename
             run: |
                 mv ./1.0/openid-4-verifiable-credential-issuance-1_0*.html ./openid-4-verifiable-credential-issuance-1_0-wg-draft.html && \
-                mv ./1.1/openid-4-verifiable-credential-issuance-1_1*.html ./openid-4-verifiable-credential-issuance-1_1-wg-draft.html
+                mv ./1.1/openid-4-verifiable-credential-issuance-1_1*.html ./openid-4-verifiable-credential-issuance-1_1-wg-draft.html && \
+                mv ./s2s/openid-4-verifiable-credential-issuance-server-2-server*.html ./openid-4-verifiable-credential-issuance-server-2-server-wg-draft.html
           - uses: actions/upload-artifact@v4
             with:
                 # Artifact name

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The current WG-Draft version is built automatically from the master branch and c
 
 * 1.0: https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-1_0-wg-draft.html
 * 1.1: https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-1_1-wg-draft.html
+* Server to Server (s2s): https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-server-2-server-wg-draft.html
 
 Other versions of the spec can be accessed at: https://openid.net/sg/openid4vc/specifications/
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to build the S2S specification automatically, similarly to versions 1.0 and 1.1, and includes a link in the README.

Resolves #795.